### PR TITLE
fix elasticsearch address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /idea/*
 /.idea/
 *.iml
+.vscode/

--- a/reportportal/templates/analyzer-statefulset.yaml
+++ b/reportportal/templates/analyzer-statefulset.yaml
@@ -18,6 +18,11 @@ spec:
 #      - image: "{{ .Values.registry }}/reportportal/service-analyzer:4.1.0"
       - image: "{{ .Values.serviceanalyzer.repository }}:{{ .Values.serviceanalyzer.tag }}"
         name: analyzer
+        env:
+        {{ if .Values.elasticsearch.endpoint.external }}
+        - name: ES_HOSTS
+          value: "http://{{ default "elasticsearch" .Values.elasticsearch.endpoint.address }}:{{ default 9200 .Values.elasticsearch.endpoint.port }}"
+        {{- end }}
         ports:
         - containerPort: 8080
           protocol: TCP


### PR DESCRIPTION
I've installed the ReportPortal to k8s cluster using this chart and found out that it tried to connect to the unexisting elasticsearch url. Please see an error in the analyzer's logs:
`ERROR Cannot send request to ES: Get http://elasticsearch:9200/_cluster/health: dial tcp: lookup elasticsearch on x.x.x.x:53: server misbehaving`. 

There is a **.Values.elasticsearch.endpoint.address** variable, but it looks like this function is not implemented yet, so I've made a try to do it. I've got **ES_HOSTS** environment variable [here](https://github.com/reportportal/service-analyzer/blob/68fad82a71d3a8fabbb13cce3dbcb493ad04d863/main.go#L76).

I would appreciate a code review and any comments.
