### PR TITLE
change uat-service name to uat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /idea/*
 /.idea/
 *.iml
+.vscode/

--- a/reportportal/templates/uat-service.yaml
+++ b/reportportal/templates/uat-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: uat-0
+  name: uat
   labels: {{ include "labels" . | indent 4 }}
 spec:
   ports:


### PR DESCRIPTION
I've got an exception when tried to delete a user:
`org.springframework.web.client.ResourceAccessException: I/O error on POST request for "http://uat:8080/sso/oauth/token": uat; nested exception is java.net.UnknownHostException: uat`.

Indeed, [service-api connects to uat:8080](https://github.com/reportportal/service-api/blob/47b341e8471e334b5aa034a7660103e6d46d6607/src/main/resources/application-docker.yaml#L18), but [the chart defines another service name](https://github.com/reportportal/kubernetes/blob/e10e9f877ab1a0e3c35ac8031cdd34c8d2d0d8ae/reportportal/templates/uat-service.yaml#L4) - uat-0:
https://github.com/reportportal/kubernetes/blob/e10e9f877ab1a0e3c35ac8031cdd34c8d2d0d8ae/reportportal/templates/uat-service.yaml#L4

I would appreciate a code review and any comments.