### PR TITLE
Adding ingress annotations to avoid 414s on large GET requests

### DIFF
--- a/reportportal/v4/values.yaml
+++ b/reportportal/v4/values.yaml
@@ -127,6 +127,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 8k
 
 # node selector for all components, if any
 nodeSelector:

--- a/reportportal/v5/values.yaml
+++ b/reportportal/v5/values.yaml
@@ -140,6 +140,7 @@ ingress:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/x-forwarded-prefix: /$1
     nginx.ingress.kubernetes.io/proxy-body-size: 128m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 8k
 
 # node selector for all components, if any
 nodeSelector:


### PR DESCRIPTION
For log GET requests our automation tests catch 414 errors. This ingress annotation updates fix that  (increases twice the parameter, default is 4k).