### PR TITLE
Update v5 names to follow chart name

### DIFF
--- a/reportportal/v5/Chart.yaml
+++ b/reportportal/v5/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+appVersion: "5.0"
 description: ReportPortal.io AI-powered Test Automation Dashboard
 name: reportportal
 version: 5.0

--- a/reportportal/v5/templates/_helpers.tpl
+++ b/reportportal/v5/templates/_helpers.tpl
@@ -1,11 +1,43 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
+Expand the name of the chart.
+*/}}
+{{- define "reportportal.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "reportportal.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "reportportal.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Generate labels
 */}}
 {{- define "labels" }}
 heritage: {{ $.Release.Service | quote }}
 release: {{ $.Release.Name | quote }}
-chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+chart: {{ include "reportportal.chart" . }}
 app: {{ $.Chart.Name | quote }}
 {{- end -}}
 

--- a/reportportal/v5/templates/analyzer-service.yaml
+++ b/reportportal/v5/templates/analyzer-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: analyzer-0
+  name: {{ include "reportportal.fullname" . }}-analyzer
   labels: {{ include "labels" . | indent 4 }}
   annotations:
     service: {{ $.Values.uat.name }}
@@ -13,5 +13,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    component: reportportal-analyzer
+    component: {{ include "reportportal.fullname" . }}-analyzer
   type: ClusterIP

--- a/reportportal/v5/templates/analyzer-statefulset.yaml
+++ b/reportportal/v5/templates/analyzer-statefulset.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: analyzer
+  name: {{ include "reportportal.fullname" . }}-analyzer
   labels: {{ include "labels" . | indent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      component: reportportal-analyzer
-  serviceName: analyzer-0
+      component: {{ include "reportportal.fullname" . }}-analyzer
+  serviceName: {{ include "reportportal.fullname" . }}-analyzer
   template:
     metadata:
       labels:
-        component: reportportal-analyzer
+        component: {{ include "reportportal.fullname" . }}-analyzer
     spec:
       containers:
       - env:

--- a/reportportal/v5/templates/api-deployment.yaml
+++ b/reportportal/v5/templates/api-deployment.yaml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: api
+  name: {{ include "reportportal.fullname" . }}-api
   labels: {{ include "labels" . | indent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      component: reportportal-api
+      component: {{ include "reportportal.fullname" . }}-api
   template:
     metadata:
       labels:
-        component: reportportal-api
+        component: {{ include "reportportal.fullname" . }}-api
     spec:
       containers:
       - env:

--- a/reportportal/v5/templates/api-service.yaml
+++ b/reportportal/v5/templates/api-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: api-0
+  name: {{ include "reportportal.fullname" . }}-api
   labels: {{ include "labels" . | indent 4 }}
   annotations:
     service: {{ $.Values.serviceapi.name }}
@@ -13,5 +13,6 @@ spec:
     protocol: TCP
     targetPort: 8585
   selector:
-    component: reportportal-api
-  type: ClusterIP  
+    component: {{ include "reportportal.fullname" . }}-api
+  type: ClusterIP
+

--- a/reportportal/v5/templates/gateway-ingress.yaml
+++ b/reportportal/v5/templates/gateway-ingress.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.ingress.enable }}
+{{- $fullName := include "reportportal.fullname" . -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: reportportal-gateway-ingress
+  name: {{ $fullName }}-gateway-ingress
   labels: {{ include "labels" . | indent 4 }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
@@ -21,40 +22,40 @@ spec:
       paths:
       - path: /()?(.*)
         backend:
-          serviceName: index-0
+          serviceName: {{ $fullName }}-index
           servicePort: headless
       - path: /(ui)/?(.*)
         backend:
-          serviceName: ui-0
+          serviceName: {{ $fullName }}-ui
           servicePort: headless
       - path: /(uat)/?(.*)
         backend:
-          serviceName: uat-0
+          serviceName: {{ $fullName }}-uat
           servicePort: headless
       - path: /(api)/?(.*)
         backend:
-            serviceName: api-0
-            servicePort: headless
+          serviceName: {{ $fullName }}-api
+          servicePort: headless
   {{- end -}}
 {{ else }}
   - http:
       paths:
       - path: /()?(.*)
         backend:
-          serviceName: index-0
+          serviceName: {{ $fullName }}-index
           servicePort: headless
       - path: /(ui)/?(.*)
         backend:
-          serviceName: ui-0
+          serviceName: {{ $fullName }}-ui
           servicePort: headless
       - path: /(uat)/?(.*)
         backend:
-          serviceName: uat-0
+          serviceName: {{ $fullName }}-uat
           servicePort: headless
       - path: /(api)/?(.*)
         backend:
-            serviceName: api-0
-            servicePort: headless
+          serviceName: {{ $fullName }}-api
+          servicePort: headless
 {{ end }}
 status:
   loadBalancer: {}

--- a/reportportal/v5/templates/index-deployment.yaml
+++ b/reportportal/v5/templates/index-deployment.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: index
+  name: {{ include "reportportal.fullname" . }}-index
   labels: {{ include "labels" . | indent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      component: reportportal-index
-  serviceName: index-0
+      component: {{ include "reportportal.fullname" . }}-index
+  serviceName: {{ include "reportportal.fullname" . }}-index
   template:
     metadata:
       labels:
-        component: reportportal-index
+        component: {{ include "reportportal.fullname" . }}-index
     spec:
       serviceAccountName: {{ template "reportportal.serviceAccountName" . }}
       containers:

--- a/reportportal/v5/templates/index-service.yaml
+++ b/reportportal/v5/templates/index-service.yaml
@@ -1,12 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: index-0
+  name: {{ include "reportportal.fullname" . }}-index
   labels: {{ include "labels" . | indent 4 }}
   annotations:
     service: {{ $.Values.serviceindex.name }}
     infoEndpoint: {{ $.Values.rp.infoEndpoint | default "/info"}}
-
 spec:
   ports:
   - name: headless
@@ -14,5 +13,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    component: reportportal-index
+    component: {{ include "reportportal.fullname" . }}-index
   type: ClusterIP

--- a/reportportal/v5/templates/migrations-job.yaml
+++ b/reportportal/v5/templates/migrations-job.yaml
@@ -1,13 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: migrations
+  name: {{ include "reportportal.fullname" . }}-migrations
   labels: {{ include "labels" . | indent 4 }}
 spec:
   template:
     metadata:
       labels:
-        component: reportportal-migrations
+        component: {{ include "reportportal.fullname" . }}-migrations
     spec:
       restartPolicy: Never
       containers:

--- a/reportportal/v5/templates/reportportal-serviceaccount.yaml
+++ b/reportportal/v5/templates/reportportal-serviceaccount.yaml
@@ -9,7 +9,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-    name: rp-service-reader
+    name: {{ include "reportportal.fullname" . }}-service-reader
     namespace: {{ .Release.Namespace }}
 rules:
     - apiGroups:
@@ -20,12 +20,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-    name: reportportal-user-binding
+    name: {{ include "reportportal.fullname" . }}-user-binding
     namespace: {{ .Release.Namespace }}
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role
-    name: rp-service-reader
+    name: {{ include "reportportal.fullname" . }}-service-reader
 subjects:
     - kind: ServiceAccount
       name: {{ template "reportportal.serviceAccountName" . }}

--- a/reportportal/v5/templates/uat-deployment.yaml
+++ b/reportportal/v5/templates/uat-deployment.yaml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: uat
+  name: {{ include "reportportal.fullname" . }}-uat
   labels: {{ include "labels" . | indent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      component: reportportal-uat
+      component: {{ include "reportportal.fullname" . }}-uat
   template:
     metadata:
       labels:
-        component: reportportal-uat
+        component: {{ include "reportportal.fullname" . }}-uat
     spec:
       containers:
       - env:

--- a/reportportal/v5/templates/uat-service.yaml
+++ b/reportportal/v5/templates/uat-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: uat-0
+  name: {{ include "reportportal.fullname" . }}-uat
   labels: {{ include "labels" . | indent 4 }}
   annotations:
     service: {{ $.Values.uat.name }}
@@ -13,5 +13,5 @@ spec:
     protocol: TCP
     targetPort: 9999
   selector:
-    component: reportportal-uat
+    component: {{ include "reportportal.fullname" . }}-uat
   type: ClusterIP

--- a/reportportal/v5/templates/ui-deployment.yaml
+++ b/reportportal/v5/templates/ui-deployment.yaml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ui
+  name: {{ include "reportportal.fullname" . }}-ui
   labels: {{ include "labels" . | indent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      component: reportportal-ui
+      component: {{ include "reportportal.fullname" . }}-ui
   template:
     metadata:
       labels:
-        component: reportportal-ui
+        component: {{ include "reportportal.fullname" . }}-ui
     spec:
       containers:
       - env:

--- a/reportportal/v5/templates/ui-service.yaml
+++ b/reportportal/v5/templates/ui-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ui-0
+  name: {{ include "reportportal.fullname" . }}-ui
   labels: {{ include "labels" . | indent 4 }}
   annotations:
     service: {{ $.Values.serviceui.name }}
@@ -13,5 +13,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    component: reportportal-ui
+    component: {{ include "reportportal.fullname" . }}-ui
   type: ClusterIP

--- a/reportportal/v5/values.yaml
+++ b/reportportal/v5/values.yaml
@@ -1,3 +1,11 @@
+## String to partially override reportportal.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override reportportal.fullname template
+##
+# fullnameOverride:
+
 serviceindex:
   name: index
   repository: reportportal/service-index
@@ -142,7 +150,7 @@ ingress:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/x-forwarded-prefix: /$1
     nginx.ingress.kubernetes.io/proxy-body-size: 128m
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 8k    
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 8k
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"


### PR DESCRIPTION
When deploying the chart, I noticed that lots of the resources
generated do not have a name that can be controlled when doing
'helm install --name <something>'.

I used content generated by 'helm create' + best practices
from other charts and introduced a 'reportportal.fullname' that
is used to build the resource names.