### PR TITLE
Improve JAVA_OPTS declaration for API and Authorization services

### DIFF
--- a/reportportal/v5/templates/api-deployment.yaml
+++ b/reportportal/v5/templates/api-deployment.yaml
@@ -30,8 +30,10 @@ spec:
         - name: RP_AMQP_QUEUESPERPOD
           value: "10"
         {{ end }}
+        {{ if .Values.serviceapi.jvmArgs }}
         - name: "JAVA_OPTS"
           value: "{{ .Values.serviceapi.jvmArgs }}"
+        {{ end }}
         - name: RP_AMQP_HOST
           value: "{{ .Values.rabbitmq.endpoint.address }}"
         - name: RP_AMQP_PORT

--- a/reportportal/v5/templates/api-deployment.yaml
+++ b/reportportal/v5/templates/api-deployment.yaml
@@ -31,7 +31,7 @@ spec:
           value: "10"
         {{ end }}
         - name: "JAVA_OPTS"
-          value: {{ .Values.serviceapi.jvmArgs | default "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp  -Dcom.sun.management.jmxremote.rmi.port=12349 -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=10.6.128.241" | quote }}
+          value: "{{ .Values.serviceapi.jvmArgs }}"
         - name: RP_AMQP_HOST
           value: "{{ .Values.rabbitmq.endpoint.address }}"
         - name: RP_AMQP_PORT

--- a/reportportal/v5/templates/api-deployment.yaml
+++ b/reportportal/v5/templates/api-deployment.yaml
@@ -15,9 +15,9 @@ spec:
     spec:
       containers:
       - env:
-        - name: "LOGGING_LEVEL_ORG_HIBERNATE_SQL"
+        - name: LOGGING_LEVEL_ORG_HIBERNATE_SQL
           value: "info"
-        - name: "RP_REQUESTLOGGING"
+        - name: RP_REQUESTLOGGING
           value: "false"
         {{ if .Values.serviceapi.queues }}
         - name: RP_AMQP_QUEUES
@@ -31,7 +31,7 @@ spec:
           value: "10"
         {{ end }}
         {{ if .Values.serviceapi.jvmArgs }}
-        - name: "JAVA_OPTS"
+        - name: JAVA_OPTS
           value: "{{ .Values.serviceapi.jvmArgs }}"
         {{ end }}
         - name: RP_AMQP_HOST

--- a/reportportal/v5/templates/migrations-job.yaml
+++ b/reportportal/v5/templates/migrations-job.yaml
@@ -3,6 +3,9 @@ kind: Job
 metadata:
   name: {{ include "reportportal.fullname" . }}-migrations
   labels: {{ include "labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:
     metadata:

--- a/reportportal/v5/templates/uat-deployment.yaml
+++ b/reportportal/v5/templates/uat-deployment.yaml
@@ -15,8 +15,12 @@ spec:
     spec:
       containers:
       - env:
+        {{ if .Values.serviceapi.jvmArgs }}
+        - name: JAVA_OPTS
+          value: "{{ .Values.uat.jvmArgs }}"
+        {{ end }}
         - name: RP_SESSION_LIVE
-          value: "3600"
+          value: "{{ .Values.uat.sessionLiveTime }}"
         - name: RP_DB_HOST
           value: "{{ .Values.postgresql.endpoint.address }}"
         - name: RP_DB_PORT

--- a/reportportal/v5/templates/uat-deployment.yaml
+++ b/reportportal/v5/templates/uat-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - env:
-        {{ if .Values.serviceapi.jvmArgs }}
+        {{ if .Values.uat.jvmArgs }}
         - name: JAVA_OPTS
           value: "{{ .Values.uat.jvmArgs }}"
         {{ end }}

--- a/reportportal/v5/values.yaml
+++ b/reportportal/v5/values.yaml
@@ -63,7 +63,7 @@ serviceapi:
     limits:
       cpu: 1000m
       memory: 2048Mi
-  jvmArgs: "-XX:+UnlockExperimentalVMOptions -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+  jvmArgs: "-Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0 -XX:+UnlockExperimentalVMOptions -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
   queues:
     totalNumber: 
     perPodNumber: 

--- a/reportportal/v5/values.yaml
+++ b/reportportal/v5/values.yaml
@@ -31,7 +31,8 @@ uat:
     limits:
       cpu: 500m
       memory: 2048Mi
-  sessionLiveTime: 86400
+  sessionLiveTime: 43200
+  jvmArgs: "-Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0"
 
 serviceui:
   repository: reportportal/service-ui

--- a/reportportal/v5/values.yaml
+++ b/reportportal/v5/values.yaml
@@ -63,7 +63,7 @@ serviceapi:
     limits:
       cpu: 1000m
       memory: 2048Mi
-  jvmArgs: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+  jvmArgs: "-XX:+UnlockExperimentalVMOptions -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
   queues:
     totalNumber: 
     perPodNumber: 

--- a/reportportal/v5/values.yaml
+++ b/reportportal/v5/values.yaml
@@ -63,7 +63,7 @@ serviceapi:
     limits:
       cpu: 1000m
       memory: 2048Mi
-  jvmArgs: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp "
+  jvmArgs: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
   queues:
     totalNumber: 
     perPodNumber: 


### PR DESCRIPTION
**GitHub issue link** - https://github.com/reportportal/reportportal/issues/864

### Changelog
- remove redundant default JAVA_OPTS declaration in the template for API based on previous commit https://github.com/reportportal/kubernetes/commit/9985c30b4ccc8527211c080b5aed4c5fcec6638f
- helm hooks for removing of old migrations job before deploy
- remove deprecated `UseCGroupMemoryLimitForHeap` JVM param as RP is using `Java 8u191+` and these versions support `UseContainerSupport` JVM param 
- allow JVM to control max HEAP_SIZE depends on POD memory limits for API service with `-XX:MinRAMPercentage=60.0` and  `-XX:MaxRAMPercentage=90.0` parameters
- add default JAVA_OPTS to UAT-service
- increase default session TTL to 12h in UAT service config

`MaxRAMPercentage` JVM parameter uses in a couple with `UseContainerSupport` feature that supports Java heap size control depends on cgroup memory limits in containers.

For example, on 2GBi memory limit for API-service K8S pod:
```
/ # java -Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0 -XshowSettings:vm -version
VM settings:
    Max. Heap Size (Estimated): 1.74G
    Ergonomics Machine Class: server
    Using VM: OpenJDK 64-Bit Server VM
openjdk version "1.8.0_212"
OpenJDK Runtime Environment (IcedTea 3.12.0) (Alpine 8.212.04-r0)
OpenJDK 64-Bit Server VM (build 25.212-b04, mixed mode)
```