### PR TITLE
Fix #106: no hard-coded URL schema for ES in PR v5

### DIFF
--- a/reportportal/v5/README.md
+++ b/reportportal/v5/README.md
@@ -359,7 +359,6 @@ elasticsearch:
   installdep:
     enable: false
   endpoint:
-    external: true
     cloudservice: true
     address: <AWS ES domain Endpoint URL>
     port: 9200

--- a/reportportal/v5/templates/analyzer-statefulset.yaml
+++ b/reportportal/v5/templates/analyzer-statefulset.yaml
@@ -31,9 +31,9 @@ spec:
           value: "analyzer-default"
         - name: ES_HOSTS
         {{ if .Values.elasticsearch.endpoint.cloudservice }}
-          value: "http://{{ .Values.elasticsearch.endpoint.address }}"
+          value: "{{ .Values.elasticsearch.endpoint.address }}"
         {{ else }}
-          value: "http://{{ .Values.elasticsearch.endpoint.address }}:{{ .Values.elasticsearch.endpoint.port }}"
+          value: "{{ .Values.elasticsearch.endpoint.address }}:{{ .Values.elasticsearch.endpoint.port }}"
         {{ end }}
         image: "{{ .Values.serviceanalyzer.repository }}:{{ .Values.serviceanalyzer.tag }}"
         name: analyzer

--- a/reportportal/v5/values.yaml
+++ b/reportportal/v5/values.yaml
@@ -123,7 +123,7 @@ elasticsearch:
     enable: false
   endpoint:
     cloudservice: false
-    address: elasticsearch-master
+    address: http://elasticsearch-master
     port: 9200
 
 minio:


### PR DESCRIPTION
This PR allows to connect to *https://* based ElasticSearch endpoint (for example in AWS within VPC).
It makes URL schema a part of `elasticsearch.endpoint.address` value and set to `http://` by default.