### PR TITLE
Updated missing MiniIO secretName key and added annotations

### DIFF
--- a/reportportal/v5/templates/analyzer-statefulset.yaml
+++ b/reportportal/v5/templates/analyzer-statefulset.yaml
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         component: {{ include "reportportal.fullname" . }}-analyzer
+      annotations:
+        {{- range $key, $value := .Values.serviceanalyzer.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       containers:
       - env:

--- a/reportportal/v5/templates/api-deployment.yaml
+++ b/reportportal/v5/templates/api-deployment.yaml
@@ -12,6 +12,10 @@ spec:
     metadata:
       labels:
         component: {{ include "reportportal.fullname" . }}-api
+      annotations:
+        {{- range $key, $value := .Values.serviceapi.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       containers:
       - env:

--- a/reportportal/v5/templates/index-deployment.yaml
+++ b/reportportal/v5/templates/index-deployment.yaml
@@ -12,6 +12,10 @@ spec:
     metadata:
       labels:
         component: {{ include "reportportal.fullname" . }}-index
+      annotations:
+        {{- range $key, $value := .Values.serviceindex.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "reportportal.serviceAccountName" . }}
       containers:

--- a/reportportal/v5/templates/migrations-job.yaml
+++ b/reportportal/v5/templates/migrations-job.yaml
@@ -8,6 +8,10 @@ spec:
     metadata:
       labels:
         component: {{ include "reportportal.fullname" . }}-migrations
+      annotations:
+        {{- range $key, $value := .Values.migrations.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       restartPolicy: Never
       containers:

--- a/reportportal/v5/templates/uat-deployment.yaml
+++ b/reportportal/v5/templates/uat-deployment.yaml
@@ -12,6 +12,10 @@ spec:
     metadata:
       labels:
         component: {{ include "reportportal.fullname" . }}-uat
+      annotations:
+        {{- range $key, $value := .Values.uat.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       containers:
       - env:

--- a/reportportal/v5/templates/ui-deployment.yaml
+++ b/reportportal/v5/templates/ui-deployment.yaml
@@ -12,6 +12,10 @@ spec:
     metadata:
       labels:
         component: {{ include "reportportal.fullname" . }}-ui
+      annotations:
+        {{- range $key, $value := .Values.serviceui.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       containers:
       - env:

--- a/reportportal/v5/values.yaml
+++ b/reportportal/v5/values.yaml
@@ -18,6 +18,7 @@ serviceindex:
     limits:
       cpu: 200m
       memory: 256Mi
+  podAnnotations: {}
 
 uat:
   repository: reportportal/service-authorization
@@ -32,6 +33,7 @@ uat:
       cpu: 500m
       memory: 2048Mi
   sessionLiveTime: 86400
+  podAnnotations: {}
 
 serviceui:
   repository: reportportal/service-ui
@@ -45,6 +47,7 @@ serviceui:
     limits:
       cpu: 200m
       memory: 128Mi
+  podAnnotations: {}
 
 serviceapi:
   repository: reportportal/service-api
@@ -67,6 +70,7 @@ serviceapi:
   queues:
     totalNumber: 
     perPodNumber: 
+  podAnnotations: {}
 
 migrations:
   repository: reportportal/migrations
@@ -79,6 +83,7 @@ migrations:
     limits:
       cpu: 100m
       memory: 128Mi
+  podAnnotations: {}
 
 serviceanalyzer:
   repository: reportportal/service-analyzer
@@ -92,6 +97,7 @@ serviceanalyzer:
     limits:
       cpu: 100m
       memory: 512Mi
+  podAnnotations: {}
 
 rabbitmq:
   SecretName: ""
@@ -127,6 +133,7 @@ elasticsearch:
     port: 9200
 
 minio:
+  secretName: ""
   enabled: true
   installdep:
     enable: false


### PR DESCRIPTION
MinIO secretName key is missing in values.yaml while being referenced in templates to set access_key and secret_key env vars. 
Also Adding the annotations for other components in order to set IAM roles when using KIAM or kube2iam while accessing AWS services like ElasticSearch , RDS and S3 bucket for MinIO.