### PR TITLE
Patch helm charts to allow configuration of security context, service account name, and migrations hooks

### DIFF
--- a/reportportal/v5/templates/analyzer-statefulset.yaml
+++ b/reportportal/v5/templates/analyzer-statefulset.yaml
@@ -48,3 +48,6 @@ spec:
             cpu: {{ .Values.serviceanalyzer.resources.limits.cpu }}
             memory: {{ .Values.serviceanalyzer.resources.limits.memory }}
 {{ include "nodeSelector" . | indent 8 }}
+      securityContext:
+{{ toYaml .Values.serviceanalyzer.securityContext | indent 8}}
+      serviceAccountName: {{ .Values.serviceanalyzer.serviceAccountName }}

--- a/reportportal/v5/templates/api-deployment.yaml
+++ b/reportportal/v5/templates/api-deployment.yaml
@@ -133,3 +133,6 @@ spec:
           timeoutSeconds: {{ .Values.serviceapi.readinessProbe.timeoutSeconds }}
           failureThreshold: {{ .Values.serviceapi.readinessProbe.failureThreshold }}
 {{ include "nodeSelector" . | indent 8 }}
+      securityContext:
+{{ toYaml .Values.serviceapi.securityContext | indent 8}}
+      serviceAccountName: {{ .Values.serviceapi.serviceAccountName }}

--- a/reportportal/v5/templates/index-deployment.yaml
+++ b/reportportal/v5/templates/index-deployment.yaml
@@ -47,3 +47,6 @@ spec:
             cpu: {{ .Values.serviceindex.resources.limits.cpu }}
             memory: {{ .Values.serviceindex.resources.limits.memory }}
 {{ include "nodeSelector" . | indent 8 }}
+      securityContext:
+{{ toYaml .Values.serviceindex.securityContext | indent 8}}
+      serviceAccountName: {{ .Values.serviceindex.serviceAccountName }}

--- a/reportportal/v5/templates/migrations-job.yaml
+++ b/reportportal/v5/templates/migrations-job.yaml
@@ -46,3 +46,6 @@ spec:
             cpu: {{ .Values.migrations.resources.limits.cpu }}
             memory: {{ .Values.migrations.resources.limits.memory }}
 {{ include "nodeSelector" . | indent 8 }}
+      securityContext:
+{{ toYaml .Values.migrations.securityContext | indent 8}}
+      serviceAccountName: {{ .Values.migrations.serviceAccountName }}

--- a/reportportal/v5/templates/migrations-job.yaml
+++ b/reportportal/v5/templates/migrations-job.yaml
@@ -3,9 +3,12 @@ kind: Job
 metadata:
   name: {{ include "reportportal.fullname" . }}-migrations
   labels: {{ include "labels" . | indent 4 }}
+{{- if .Values.migrations.metadataAnnotations.enabled }}
   annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    {{- range $key, $value := .Values.migrations.metadataAnnotations.hooks }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+{{- end }}
 spec:
   template:
     metadata:

--- a/reportportal/v5/templates/uat-deployment.yaml
+++ b/reportportal/v5/templates/uat-deployment.yaml
@@ -88,3 +88,6 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 5
 {{ include "nodeSelector" . | indent 8 }}
+      securityContext:
+{{ toYaml .Values.uat.securityContext | indent 8}}
+      serviceAccountName: {{ .Values.uat.serviceAccountName }}

--- a/reportportal/v5/templates/ui-deployment.yaml
+++ b/reportportal/v5/templates/ui-deployment.yaml
@@ -41,3 +41,6 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
 {{ include "nodeSelector" . | indent 8 }}
+      securityContext:
+{{ toYaml .Values.serviceui.securityContext | indent 8}}
+      serviceAccountName: {{ .Values.serviceui.serviceAccountName }}

--- a/reportportal/v5/values.yaml
+++ b/reportportal/v5/values.yaml
@@ -19,6 +19,8 @@ serviceindex:
       cpu: 200m
       memory: 256Mi
   podAnnotations: {}
+  serviceContext: {}
+  serviceAccountName: ""
 
 uat:
   repository: reportportal/service-authorization
@@ -35,6 +37,8 @@ uat:
   sessionLiveTime: 86400
   podAnnotations: {}
   jvmArgs: "-Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0"
+  serviceContext: {}
+  serviceAccountName: ""
 
 serviceui:
   repository: reportportal/service-ui
@@ -49,6 +53,8 @@ serviceui:
       cpu: 200m
       memory: 128Mi
   podAnnotations: {}
+  serviceContext: {}
+  serviceAccountName: ""
 
 serviceapi:
   repository: reportportal/service-api
@@ -72,6 +78,8 @@ serviceapi:
     totalNumber: 
     perPodNumber: 
   podAnnotations: {}
+  serviceContext: {}
+  serviceAccountName: ""
 
 migrations:
   repository: reportportal/migrations
@@ -85,6 +93,8 @@ migrations:
       cpu: 100m
       memory: 128Mi
   podAnnotations: {}
+  serviceContext: {}
+  serviceAccountName: ""
 
 serviceanalyzer:
   repository: reportportal/service-auto-analyzer
@@ -99,6 +109,8 @@ serviceanalyzer:
       cpu: 100m
       memory: 512Mi
   podAnnotations: {}
+  serviceContext: {}
+  serviceAccountName: ""
 
 rabbitmq:
   SecretName: ""

--- a/reportportal/v5/values.yaml
+++ b/reportportal/v5/values.yaml
@@ -95,6 +95,11 @@ migrations:
   podAnnotations: {}
   serviceContext: {}
   serviceAccountName: ""
+  metadataAnnotations:
+    enabled: true
+    hooks:
+      "helm.sh/hook": "pre-install,pre-upgrade"
+      "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 
 serviceanalyzer:
   repository: reportportal/service-auto-analyzer


### PR DESCRIPTION
Adds configuration options for security context and service account name to all pods.  In addition, allows the migration job's hooks to be configured