### PR TITLE
Adding support for Traefik ingress

### DIFF
--- a/reportportal/v5/Chart.yaml
+++ b/reportportal/v5/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "5.2.0"
+appVersion: "5.3.0"
 description: ReportPortal.io AI-powered Test Automation Dashboard
 name: reportportal
-version: 5.2.1
+version: 5.3.0
 sources:
   - https://github.com/reportportal/k8s/reportportal
 keywords:

--- a/reportportal/v5/templates/gateway-ingress.yaml
+++ b/reportportal/v5/templates/gateway-ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enable }}
 {{- $fullName := include "reportportal.fullname" . -}}
+{{- $paths := .Values.ingress.paths -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -15,48 +16,30 @@ spec:
 {{ toYaml .Values.ingress.tls | indent 4 }}
 {{- end}}
   rules:
-{{ if .Values.ingress.usedomainname }}
+{{- if .Values.ingress.usedomainname }}
+  {{- if .Values.ingress.hosts }}
   {{- range $host := .Values.ingress.hosts }}
-  - host: {{ $host }}
-    http:
-      paths:
-      - path: /()?(.*)
-        backend:
-          serviceName: {{ $fullName }}-index
-          servicePort: headless
-      - path: /(ui)/?(.*)
-        backend:
-          serviceName: {{ $fullName }}-ui
-          servicePort: headless
-      - path: /(uat)/?(.*)
-        backend:
-          serviceName: {{ $fullName }}-uat
-          servicePort: headless
-      - path: /(api)/?(.*)
-        backend:
-          serviceName: {{ $fullName }}-api
-          servicePort: headless
+    - host: {{ $host }}
+      http:
+        paths:
+  {{- range $svc, $p := $paths }}
+          - path: {{ $p }}
+            backend:
+              serviceName: "{{ $fullName }}-{{ $svc }}"
+              servicePort: headless
   {{- end -}}
-{{ else }}
-  - http:
-      paths:
-      - path: /()?(.*)
-        backend:
-          serviceName: {{ $fullName }}-index
-          servicePort: headless
-      - path: /(ui)/?(.*)
-        backend:
-          serviceName: {{ $fullName }}-ui
-          servicePort: headless
-      - path: /(uat)/?(.*)
-        backend:
-          serviceName: {{ $fullName }}-uat
-          servicePort: headless
-      - path: /(api)/?(.*)
-        backend:
-          serviceName: {{ $fullName }}-api
-          servicePort: headless
-{{ end }}
+  {{- end -}}
+  {{- else }}
+    - http:
+        paths:
+  {{- range $svc, $p := $paths }}
+          - path: {{ $p }}
+            backend:
+              serviceName: "{{ $fullName }}-{{ $svc }}"
+              servicePort: headless
+  {{- end -}}
+  {{- end -}}
+  {{- end }}
 status:
   loadBalancer: {}
 {{- end }}

--- a/reportportal/v5/values.yaml
+++ b/reportportal/v5/values.yaml
@@ -166,6 +166,11 @@ ingress:
   usedomainname: false
   hosts:
     - reportportal.k8.com
+  paths:
+    index: "/()?(.*)"
+    ui: "/(ui)/?(.*)"
+    uat: "/(uat)/?(.*)"
+    api: "/(api)/?(.*)"
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"


### PR DESCRIPTION
This PR would add support for Traefik ingress controller. Updated paths which would work for Traefik as well. 

This is the only change required in gateway-ingress to make it compatible with Traefik, the annotations and `pathPrefix` can be overridden through helm CLI or helm values.yaml.

Tested it already and it works for us after overriding `ingress.annotations.*`  to `null` for Traefik like below:

```
      ingress.annotations.kubernetes.io/ingress.class: traefik
      ingress.annotations.traefik.frontend.rule.type: PathPrefixStrip
      ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect: "null"
      ingress.annotations.nginx.ingress.kubernetes.io/rewrite-target: "null"
      ingress.annotations.nginx.ingress.kubernetes.io/rx-forwarded-prefix: "null"
      ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size: "null"
      ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size: "null"
      ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffers-number: "null"
      ingress.annotations.nginx.ingress.kubernetes.io/proxy-busy-buffers-size: "null"
      ingress.annotations.nginx.ingress.kubernetes.io/proxy-connect-timeout: "null"
      ingress.annotations.nginx.ingress.kubernetes.io/proxy-read-timeout: "null"
      ingress.annotations.nginx.ingress.kubernetes.io/proxy-send-timeout: "null"
      ingress.annotations.nginx.ingress.kubernetes.io/x-forwarded-prefix: "null"

```