### PR TITLE
`helm init` is not needed any more

### DIFF
--- a/reportportal/v5/README.md
+++ b/reportportal/v5/README.md
@@ -151,6 +151,12 @@ Verify that the NGINX Ingress controller is running:
 kubectl get pods -n kube-system
 ```
 
+Initialize Helm package manager:  
+```sh
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+```
+
+
 > Before you deploy ReportPortal you should have installed all its requirements. Their versions are described in requirements.yaml  
 > You should also specify correct PostgreSQL and RabbitMQ addresses and ports in values.yaml  
 

--- a/reportportal/v5/README.md
+++ b/reportportal/v5/README.md
@@ -151,11 +151,6 @@ Verify that the NGINX Ingress controller is running:
 kubectl get pods -n kube-system
 ```
 
-Initialize Helm package manager:  
-```sh
-helm init
-```
-
 > Before you deploy ReportPortal you should have installed all its requirements. Their versions are described in requirements.yaml  
 > You should also specify correct PostgreSQL and RabbitMQ addresses and ports in values.yaml  
 


### PR DESCRIPTION
$ helm version
version.BuildInfo{Version:"v3.3.4", GitCommit:"a61ce5633af99708171414353ed49547cf05013d", GitTreeState:"clean", GoVersion:"go1.14.9"}

$ helm init
Error: unknown command "init" for "helm"

Did you mean this?
	lint

Run 'helm --help' for usage.