### PR TITLE
Fix #143: bump MinIO dependency version

### DIFF
--- a/reportportal/v5/Chart.yaml
+++ b/reportportal/v5/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "5.2.0"
+appVersion: "5.3.1"
 description: ReportPortal.io AI-powered Test Automation Dashboard
 name: reportportal
-version: 5.2.1
+version: 5.3.0
 sources:
   - https://github.com/reportportal/k8s/reportportal
 keywords:

--- a/reportportal/v5/requirements.yaml
+++ b/reportportal/v5/requirements.yaml
@@ -15,6 +15,6 @@ dependencies:
     condition: elasticsearch.installdep.enable
 
   - name: minio
-    version: 2.5.12
+    version: 2.5.14
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: minio.installdep.enable


### PR DESCRIPTION
The `minio` chart release `2.5.14` has been added support for new Kubernetes API.
This is the related PR: helm/charts#17072

I have tested this on Kubernetes 1.17, no Helm errors occurred.