### PR TITLE
feat: Include bucket prefix env variables

### DIFF
--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -111,6 +111,14 @@ spec:
         - name: RP_BINARYSTORE_MINIO_SECRETKEY
           value: "{{ .Values.minio.secretkey }}"
        {{ end }}
+       {{ if .Values.minio.bucketPrefix}}
+        - name: RP_BINARYSTORE_MINIO_BUCKETPREFIX
+          value: "{{ .Values.minio.bucketPrefix }}"
+       {{ end }}
+       {{ if .Values.minio.defaultBucketName}}
+        - name: RP_BINARYSTORE_MINIO_DEFAULTBUCKETNAME
+          value: "{{ .Values.minio.defaultBucketName }}"
+       {{ end }
        {{ end }}
         image: "{{ .Values.serviceapi.repository }}:{{ .Values.serviceapi.tag }}"
         name: api

--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -111,11 +111,11 @@ spec:
         - name: RP_BINARYSTORE_MINIO_SECRETKEY
           value: "{{ .Values.minio.secretkey }}"
        {{ end }}
-       {{ if .Values.minio.bucketPrefix}}
+       {{ if .Values.minio.bucketPrefix }}
         - name: RP_BINARYSTORE_MINIO_BUCKETPREFIX
           value: "{{ .Values.minio.bucketPrefix }}"
        {{ end }}
-       {{ if .Values.minio.defaultBucketName}}
+       {{ if .Values.minio.defaultBucketName }}
         - name: RP_BINARYSTORE_MINIO_DEFAULTBUCKETNAME
           value: "{{ .Values.minio.defaultBucketName }}"
        {{ end }}

--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -118,7 +118,7 @@ spec:
        {{ if .Values.minio.defaultBucketName}}
         - name: RP_BINARYSTORE_MINIO_DEFAULTBUCKETNAME
           value: "{{ .Values.minio.defaultBucketName }}"
-       {{ end }
+       {{ end }}
        {{ end }}
         image: "{{ .Values.serviceapi.repository }}:{{ .Values.serviceapi.tag }}"
         name: api

--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -119,6 +119,10 @@ spec:
         - name: RP_BINARYSTORE_MINIO_DEFAULTBUCKETNAME
           value: "{{ .Values.minio.defaultBucketName }}"
        {{ end }}
+       {{ if .Values.minio.defaultBucketName }}
+        - name: RP_INTEGRATION_SALT_PATH
+          value: "{{ .Values.minio.defaultBucketName }}"
+       {{ end }}
        {{ end }}
         image: "{{ .Values.serviceapi.repository }}:{{ .Values.serviceapi.tag }}"
         name: api

--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -119,9 +119,9 @@ spec:
         - name: RP_BINARYSTORE_MINIO_DEFAULTBUCKETNAME
           value: "{{ .Values.minio.defaultBucketName }}"
        {{ end }}
-       {{ if .Values.minio.defaultBucketName }}
+       {{ if .Values.minio.integrationSaltPath }}
         - name: RP_INTEGRATION_SALT_PATH
-          value: "{{ .Values.minio.defaultBucketName }}"
+          value: "{{ .Values.minio.integrationSaltPath }}"
        {{ end }}
        {{ end }}
         image: "{{ .Values.serviceapi.repository }}:{{ .Values.serviceapi.tag }}"

--- a/reportportal/templates/uat-deployment.yaml
+++ b/reportportal/templates/uat-deployment.yaml
@@ -66,6 +66,14 @@ spec:
         - name: RP_BINARYSTORE_MINIO_SECRETKEY
           value: "{{ .Values.minio.secretkey }}"
         {{ end }}
+        {{ if .Values.minio.bucketPrefix}}
+        - name: RP_BINARYSTORE_MINIO_BUCKETPREFIX
+          value: "{{ .Values.minio.bucketPrefix }}"
+        {{ end }}
+        {{ if .Values.minio.defaultBucketName}}
+        - name: RP_BINARYSTORE_MINIO_DEFAULTBUCKETNAME
+          value: "{{ .Values.minio.defaultBucketName }}"
+        {{ end }}
         {{ end }}
         name: uat
         image: "{{ .Values.uat.repository }}:{{ .Values.uat.tag }}"

--- a/reportportal/templates/uat-deployment.yaml
+++ b/reportportal/templates/uat-deployment.yaml
@@ -74,6 +74,10 @@ spec:
         - name: RP_BINARYSTORE_MINIO_DEFAULTBUCKETNAME
           value: "{{ .Values.minio.defaultBucketName }}"
         {{ end }}
+        {{ if .Values.minio.integrationSaltPath }}
+        - name: RP_INTEGRATION_SALT_PATH
+          value: "{{ .Values.minio.integrationSaltPath }}"
+        {{ end }}
         {{ end }}
         name: uat
         image: "{{ .Values.uat.repository }}:{{ .Values.uat.tag }}"

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -157,6 +157,8 @@ minio:
   region:
   accesskey: <minio-accesskey>
   secretkey: <minio-secretkey>
+  bucketPrefix: ""
+  defaultBucketName: ""
 
 # Ingress configuration for the ui
 # If you have installed ingress controller and want to expose application - set INGRESS.ENABLE to true.

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -159,6 +159,7 @@ minio:
   secretkey: <minio-secretkey>
   bucketPrefix: ""
   defaultBucketName: ""
+  integrationSaltPath: ""
 
 # Ingress configuration for the ui
 # If you have installed ingress controller and want to expose application - set INGRESS.ENABLE to true.


### PR DESCRIPTION
This adds the minio environment variables that define bucket prefixes.

These features were included in https://github.com/reportportal/commons-dao/pull/642 and https://github.com/reportportal/service-api/pull/1206.

Also related: https://github.com/reportportal/reportportal/issues/1064