### PR TITLE
Support using existing secrets with cloud services

### DIFF
--- a/reportportal/templates/uat-deployment.yaml
+++ b/reportportal/templates/uat-deployment.yaml
@@ -31,14 +31,15 @@ spec:
           value: "{{ .Values.postgresql.endpoint.port }}"
         - name: RP_DB_USER
           value: "{{ .Values.postgresql.endpoint.user }}"
+        {{ if .Values.postgresql.SecretName }}
         - name: RP_DB_PASS
-        {{ if .Values.postgresql.endpoint.cloudservice }}
-          value: "{{ .Values.postgresql.endpoint.password }}"
-        {{ else }}
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.postgresql.SecretName }}"
               key: "postgresql-password"
+        {{ else }}
+        - name: RP_DB_PASS
+          value: "{{ .Values.postgresql.endpoint.password }}"
         {{ end }}
         {{ if .Values.minio.enabled }}
         - name: RP_BINARYSTORE_TYPE


### PR DESCRIPTION
Right now, supplying `postgresql.endpoint.cloudservice` requires the postgres password to be from values instead of supporting K8s secrets. Using cloudservice shouldn't prevent you from being able to use k8s secrets to store the credentials. This follows conventions seen often in other charts.

~This is slightly breaking because it now expect anyone who uses `postgresql.SecretName` to also define `postgresql-user` in the secret.~
Edit: This is changed to no longer touch `RP_DB_USER` so it shouldn't be a breaking change anymore