### PR TITLE
Introduce the "migrations.enabled" flag

### DIFF
--- a/reportportal/templates/migrations-job.yaml
+++ b/reportportal/templates/migrations-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.migrations.enabled }}
+{{- if or (not (hasKey .Values.migrations "enabled")) .Values.migrations.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/reportportal/templates/migrations-job.yaml
+++ b/reportportal/templates/migrations-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.migrations.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -52,3 +53,4 @@ spec:
       securityContext:
 {{ toYaml .Values.migrations.securityContext | indent 8}}
       serviceAccountName: {{ .Values.migrations.serviceAccountName }}
+{{- end }}

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -82,7 +82,6 @@ serviceapi:
   serviceAccountName: ""
 
 migrations:
-  enabled: true
   repository: reportportal/migrations
   tag: 5.3.5
   pullPolicy: Always

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -82,6 +82,7 @@ serviceapi:
   serviceAccountName: ""
 
 migrations:
+  enabled: true
   repository: reportportal/migrations
   tag: 5.3.5
   pullPolicy: Always


### PR DESCRIPTION
Introduce the "migrations.enabled" flag to provide ability to turn off migrations when it needs to use several environments with one DB.

The default behaviour won't be changed as it points out as "true" by default

Signed-off-by: valentynkvasov <valentynkvasov@gmail.com>