### PR TITLE
Fix cloudservice secrets

### DIFF
--- a/reportportal/templates/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/analyzertrain-statefulset.yaml
@@ -48,13 +48,13 @@ spec:
        {{ end }}
        {{ end }}
         - name: RP_AMQP_PASS
-        {{ if .Values.rabbitmq.endpoint.cloudservice }}
-          value: "{{ .Values.rabbitmq.endpoint.password }}"
-        {{ else }}
+        {{ if .Values.rabbitmq.SecretName }}
           valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.rabbitmq.SecretName }}"
-              key: "rabbitmq-password"
+           secretKeyRef:
+             name: "{{ .Values.rabbitmq.SecretName }}"
+             key: "rabbitmq-password"
+        {{ else }}
+          value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{ end }}
         - name: AMQP_URL
           value: "amqp://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"

--- a/reportportal/templates/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/analyzertrain-statefulset.yaml
@@ -50,9 +50,9 @@ spec:
         - name: RP_AMQP_PASS
         {{ if .Values.rabbitmq.SecretName }}
           valueFrom:
-           secretKeyRef:
-             name: "{{ .Values.rabbitmq.SecretName }}"
-             key: "rabbitmq-password"
+            secretKeyRef:
+              name: "{{ .Values.rabbitmq.SecretName }}"
+              key: "rabbitmq-password"
         {{ else }}
           value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{ end }}

--- a/reportportal/templates/jobs-deployment.yaml
+++ b/reportportal/templates/jobs-deployment.yaml
@@ -42,13 +42,13 @@ spec:
         - name: RP_DB_USER
           value: "{{ .Values.postgresql.endpoint.user }}"
         - name: RP_DB_PASS
-        {{- if .Values.postgresql.endpoint.cloudservice }}
-          value: "{{ .Values.postgresql.endpoint.password }}"
-        {{- else }}
+        {{- if .Values.postgresql.SecretName }}
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.postgresql.SecretName }}"
               key: "postgresql-password"
+        {{ else }}
+          value: "{{ .Values.postgresql.endpoint.password }}"
         {{ end }}
         {{ if .Values.minio.enabled }}
         - name: DATASTORE_TYPE


### PR DESCRIPTION
It looks like there was a bad merge between https://github.com/reportportal/kubernetes/pull/172 and https://github.com/reportportal/kubernetes/pull/160, which added some `cloudservice` references as I removed them. This corrects those secrets references.