### PR TITLE
Increace limit memory for serviceanalyzer to 768Mi

### DIFF
--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -136,7 +136,7 @@ serviceanalyzer:
       memory: 256Mi
     limits:
       cpu: 100m
-      memory: 512Mi
+      memory: 768Mi
   podAnnotations: {}
   securityContext: {}
   serviceAccountName: ""


### PR DESCRIPTION
Fix issue https://github.com/reportportal/kubernetes/issues/203