### PR TITLE
API, UAT and Jobs pods should use database name from values file

### DIFF
--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -70,6 +70,8 @@ spec:
           value: "{{ .Values.postgresql.endpoint.address }}"
         - name: RP_DB_PORT
           value: "{{ .Values.postgresql.endpoint.port }}"
+        - name: RP_DB_NAME
+          value: "{{ .Values.postgresql.endpoint.dbName }}"
         {{ if .Values.postgresql.endpoint.connections }}
         - name: RP_DATASOURCE_MAXIMUMPOOLSIZE
           value: "{{ .Values.postgresql.endpoint.connections }}"

--- a/reportportal/templates/jobs-deployment.yaml
+++ b/reportportal/templates/jobs-deployment.yaml
@@ -35,6 +35,8 @@ spec:
           value: "{{ .Values.postgresql.endpoint.address }}"
         - name: RP_DB_PORT
           value: "{{ .Values.postgresql.endpoint.port }}"
+        - name: RP_DB_NAME
+          value: "{{ .Values.postgresql.endpoint.dbName }}"
         {{- if .Values.postgresql.endpoint.connections }}
         - name: RP_DATASOURCE_MAXIMUMPOOLSIZE
           value: "{{ .Values.postgresql.endpoint.connections }}"

--- a/reportportal/templates/uat-deployment.yaml
+++ b/reportportal/templates/uat-deployment.yaml
@@ -29,6 +29,8 @@ spec:
           value: "{{ .Values.postgresql.endpoint.address }}"
         - name: RP_DB_PORT
           value: "{{ .Values.postgresql.endpoint.port }}"
+        - name: RP_DB_NAME
+          value: "{{ .Values.postgresql.endpoint.dbName }}"
         - name: RP_DB_USER
           value: "{{ .Values.postgresql.endpoint.user }}"
         - name: RP_DB_PASS


### PR DESCRIPTION
The API, UAT and Jobs pods all default the database name to 'reportportal' and ignore the value supplied in the values files, due to the RP_DB_NAME environment variable not being set.

Adding the RP_DB_NAME environment variable and setting it to postgresql.endpoint.dbName value remedies this issue.

The migration pod does not suffer this issue as it sets the relevant value correctly.