### PR TITLE
Adding ability to set environment variables for analyzer

### DIFF
--- a/reportportal/templates/analyzer-statefulset.yaml
+++ b/reportportal/templates/analyzer-statefulset.yaml
@@ -62,6 +62,10 @@ spec:
         - name: UWSGI_WORKERS
           value: "{{ .Values.serviceanalyzer.uwsgiWorkers }}"
         {{- end }}
+        {{- range .Values.serviceanalyzer.env }}
+        - name: {{ .name }}
+          value: {{ .value }}
+        {{- end }}
         image: "{{ .Values.serviceanalyzer.repository }}:{{ .Values.serviceanalyzer.tag }}"
         name: analyzer
         ports:


### PR DESCRIPTION
Service Auto Analyzer has a ton of environment variables that can change the configuration. This would enable those vars to be set in the values file as a list. https://github.com/reportportal/service-auto-analyzer#readme

Example: 
````
  env:
    - name: LOGGING_LEVEL
      value: ERROR