### PR TITLE
Adding ability to configure the protocol (amqp/amqps) for RabbitMQ

### DIFF
--- a/reportportal/templates/analyzer-statefulset.yaml
+++ b/reportportal/templates/analyzer-statefulset.yaml
@@ -53,7 +53,7 @@ spec:
           value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{ end }}
         - name: AMQP_URL
-          value: "amqp://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
+          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
         - name: AMQP_EXCHANGE_NAME
           value: "analyzer-default"
         - name: ES_HOSTS

--- a/reportportal/templates/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/analyzertrain-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{ end }}
         - name: AMQP_URL
-          value: "amqp://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
+          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
         - name: AMQP_EXCHANGE_NAME
           value: "analyzer-default"
         - name: ES_HOSTS

--- a/reportportal/templates/metrics-gatherer-deployment.yaml
+++ b/reportportal/templates/metrics-gatherer-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{ end }}
         - name: AMQP_URL
-          value: "amqp://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
+          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
         - name: LOGGING_LEVEL
           value: "{{ .Values.metricsgatherer.loggingLevel }}"
         - name: ES_HOST

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -181,6 +181,7 @@ rabbitmq:
     enable: false
   endpoint:
     address: <rabbitmq-release-name>-rabbitmq.default.svc.cluster.local
+    protocol: amqp
     port: 5672
     user: rabbitmq
     apiport: 15672


### PR DESCRIPTION
This PR Add the ability to configure the RabbitMQ protocol : AMQP or AMQPS (TLS/SSL encrypted AMQP).

This is usefull in case of using this chart with Amazon MQ which use AMQPS.