### PR TITLE
Rabbit mq as amazon mq brocker

### DIFF
--- a/reportportal/README.md
+++ b/reportportal/README.md
@@ -387,35 +387,6 @@ After the pod gets the status Running, you need to configure the RabbitMQ memory
 kubectl exec -it <rabbitmq_pod_name> -- rabbitmqctl set_vm_memory_high_watermark 0.8
 ```
 
-5.2 RabbitMQ as AmazoneMQ brocker
-
-Amazon MQ is a managed message broker service for that makes it easy to migrate to a message broker in the cloud. Use the AWS manual to create [RabbitMQ brocker](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/getting-started-rabbitmq.html#create-rabbitmq-broker)
-
-Edit `api-deployment.yaml` in `reportportal/templates/` folder
-
-```yaml
-- name: RP_AMQP_ADDRESSES
-  value: "amqps://{{ .Values.rabbitmq.endpoint.user }}:{{ .Values.rabbitmq.endpoint.password }}@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}"
-- name: RP_AMQP_API_ADDRESS
-  value: "https://{{ .Values.rabbitmq.endpoint.user }}:{{ .Values.rabbitmq.endpoint.password }}@{{ .Values.rabbitmq.endpoint.address }}/api"
-```
-
-Edit values.yaml in `reportportal/` folder
-
-```yaml
-rabbitmq:
-  SecretName: ''
-  installdep:
-    enable: false
-  endpoint:
-    address: <RABBITMQ_CLOUD_ADDRESS>
-    port: <RABBITMQ_PORT>  # for example 5671
-    user: <RABBITMQ_USERNAME>
-    apiport: 1<RABBITMQ_PORT>  # for expample 15671
-    apiuser: <RABBITMQ_USERNAME>
-    password: <RABBITMQ_PASSWORD>
-```
-
 #### 6. PostgreSQL installation
 
 You can install PostgreSQL from the [PostgreSQL Helm chart](https://github.com/helm/charts/tree/master/stable/postgresql) (6.1) or use an Amazon RDS Service for your PostgreSQL database (6.2) or Azure Database for PostgreSQL (6.3).

--- a/reportportal/templates/analyzer-statefulset.yaml
+++ b/reportportal/templates/analyzer-statefulset.yaml
@@ -53,7 +53,7 @@ spec:
           value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{ end }}
         - name: AMQP_URL
-          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
+          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.rabbitmq.endpoint.port }}/"
         - name: AMQP_EXCHANGE_NAME
           value: "analyzer-default"
         - name: ES_HOSTS

--- a/reportportal/templates/analyzer-statefulset.yaml
+++ b/reportportal/templates/analyzer-statefulset.yaml
@@ -53,7 +53,7 @@ spec:
           value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{ end }}
         - name: AMQP_URL
-          value: "amqp://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
+          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
         - name: AMQP_EXCHANGE_NAME
           value: "analyzer-default"
         - name: ES_HOSTS

--- a/reportportal/templates/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/analyzertrain-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{ end }}
         - name: AMQP_URL
-          value: "amqp://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
+          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
         - name: AMQP_EXCHANGE_NAME
           value: "analyzer-default"
         - name: ES_HOSTS

--- a/reportportal/templates/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/analyzertrain-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{ end }}
         - name: AMQP_URL
-          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
+          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.rabbitmq.endpoint.port }}/"
         - name: AMQP_EXCHANGE_NAME
           value: "analyzer-default"
         - name: ES_HOSTS

--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -39,7 +39,7 @@ spec:
           value: "{{ .Values.serviceapi.jvmArgs }}"
         {{- end }}
         - name: RP_AMQP_HOST
-          value: "{{ .Values.rabbitmq.endpoint.address }}"
+          value: "{{ .Values.rabbitmq.endpoint.address | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}"
         - name: RP_AMQP_PORT
           value: "{{ .Values.rabbitmq.endpoint.port }}"
         - name: RP_AMQP_USER
@@ -53,6 +53,10 @@ spec:
         {{- else }}
           value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{- end }}
+        - name: RP_AMQP_ADDRESSES
+          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:{{ .Values.rabbitmq.endpoint.password }}@{{ .Values.rabbitmq.endpoint.address | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.rabbitmq.endpoint.port }}"
+        - name: RP_AMQP_API_ADDRESS
+          value: "{{ .Values.rabbitmq.endpoint.apiprotocol }}://{{ .Values.rabbitmq.endpoint.user }}:{{ .Values.rabbitmq.endpoint.password }}@{{ .Values.rabbitmq.endpoint.address | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}/api"
         - name: RP_AMQP_APIPORT
           value: "{{ .Values.rabbitmq.endpoint.apiport }}"
         - name: RP_AMQP_APIUSER

--- a/reportportal/templates/jobs-deployment.yaml
+++ b/reportportal/templates/jobs-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           value: "{{ .Values.servicejobs.jvmArgs }}"
         {{- end }}
         - name: RP_AMQP_HOST
-          value: "{{ .Values.rabbitmq.endpoint.address }}"
+          value: "{{ .Values.rabbitmq.endpoint.address | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}"
         - name: RP_AMQP_PORT
           value: "{{ .Values.rabbitmq.endpoint.port }}"
         - name: RP_AMQP_USER
@@ -50,6 +50,10 @@ spec:
         {{ else }}
           value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{ end }}
+        - name: RP_AMQP_ADDRESSES
+          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:{{ .Values.rabbitmq.endpoint.password }}@{{ .Values.rabbitmq.endpoint.address | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.rabbitmq.endpoint.port }}"
+        - name: RP_AMQP_API_ADDRESS
+          value: "{{ .Values.rabbitmq.endpoint.apiprotocol }}://{{ .Values.rabbitmq.endpoint.user }}:{{ .Values.rabbitmq.endpoint.password }}@{{ .Values.rabbitmq.endpoint.address | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}/api"
         - name: RP_AMQP_APIPORT
           value: "{{ .Values.rabbitmq.endpoint.apiport }}"
         - name: RP_AMQP_APIUSER

--- a/reportportal/templates/metrics-gatherer-deployment.yaml
+++ b/reportportal/templates/metrics-gatherer-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{ end }}
         - name: AMQP_URL
-          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
+          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.rabbitmq.endpoint.port }}/"
         - name: LOGGING_LEVEL
           value: "{{ .Values.metricsgatherer.loggingLevel }}"
         - name: ES_HOST

--- a/reportportal/templates/metrics-gatherer-deployment.yaml
+++ b/reportportal/templates/metrics-gatherer-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: "{{ .Values.rabbitmq.endpoint.password }}"
         {{ end }}
         - name: AMQP_URL
-          value: "amqp://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
+          value: "{{ .Values.rabbitmq.endpoint.protocol }}://{{ .Values.rabbitmq.endpoint.user }}:$(RP_AMQP_PASS)@{{ .Values.rabbitmq.endpoint.address }}:{{ .Values.rabbitmq.endpoint.port }}/"
         - name: LOGGING_LEVEL
           value: "{{ .Values.metricsgatherer.loggingLevel }}"
         - name: ES_HOST

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -180,11 +180,13 @@ rabbitmq:
   installdep:
     enable: false
   endpoint:
-    address: <rabbitmq-release-name>-rabbitmq.default.svc.cluster.local
+    address: 
+    protocol: amqp
     port: 5672
     user: rabbitmq
     apiport: 15672
     apiuser: rabbitmq
+    apiprotocol: http
     password:
 
 postgresql:


### PR DESCRIPTION
This PR Add the ability to configure the RabbitMQ protocol : AMQP or AMQPS (TLS/SSL encrypted AMQP) and RabbitMQ api protocol  : HTTP or HTTPS.

This is usefull in case of using this chart with Amazon MQ which use AMQPS and HTTPS