### PR TITLE
Adding ability to add a secret for UAT

### DIFF
--- a/reportportal/templates/uat-deployment.yaml
+++ b/reportportal/templates/uat-deployment.yaml
@@ -101,6 +101,12 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
           failureThreshold: 5
+        volumeMounts:
+          {{- if .Values.uat.secret.enabled }}
+          - mountPath: {{ .Values.uat.secret.mountPath }}
+            name: {{ template "reportportal.name" . }}-uat-secret
+            readOnly: {{ .Values.uat.secret.readOnly }}
+          {{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
         {{- range $key, $value := .Values.nodeSelector }}
@@ -115,3 +121,9 @@ spec:
       tolerations: 
 {{- toYaml . | nindent 8 }}
 {{- end }}
+      volumes:
+        {{- if .Values.uat.secret.enabled }}
+        - name: {{ template "reportportal.name" . }}-uat-secret
+          secret:
+            secretName: {{ template "reportportal.name" . }}-uat-secret
+        {{- end }}

--- a/reportportal/templates/uat-secret.yaml
+++ b/reportportal/templates/uat-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.uat.secret.enabled .Values.uat.secret.data -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "reportportal.name" . }}-uat-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+data:
+{{ toYaml .Values.uat.secret.data | indent 2 }}
+{{- end}}

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -35,9 +35,17 @@ uat:
       memory: 2048Mi
   sessionLiveTime: 86400
   podAnnotations: {}
-  jvmArgs: "-Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0"
   securityContext: {}
   serviceAccountName: ""
+  jvmArgs: "-Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0"
+  #jvmArgs: "-Djavax.net.ssl.trustStore=/etc/secret-volume/custom-pki.jks -Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0"
+  secret:
+    enabled: false
+    mountPath: /etc/secret-volume
+    readOnly: true
+    data:
+      custom-pki.jks: <base64-data>
+
 
 serviceui:
   repository: reportportal/service-ui

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -43,9 +43,8 @@ uat:
     enabled: false
     mountPath: /etc/secret-volume
     readOnly: true
-    data:
-      custom-pki.jks: <base64-data>
-
+    data: {}
+     #custom-pki.jks: <base64-data>
 
 serviceui:
   repository: reportportal/service-ui


### PR DESCRIPTION
Adding ability to add a secret for UAT : this is usefull in case users configure LDAP over SSL and the LDAP host use a certificate signed by a private PKI.