### PR TITLE
Add optionnal init containers for all pods

### DIFF
--- a/reportportal/templates/analyzer-statefulset.yaml
+++ b/reportportal/templates/analyzer-statefulset.yaml
@@ -18,6 +18,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      initContainers:
+      {{- if .Values.extraInitContainers }}
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+      {{- end }}
       containers:
       - env:
       {{ if .Values.minio.enabled }}

--- a/reportportal/templates/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/analyzertrain-statefulset.yaml
@@ -18,6 +18,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      initContainers:
+      {{- if .Values.extraInitContainers }}
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+      {{- end }}
       containers:
       - env:
         - name: INSTANCE_TASK_TYPE

--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      initContainers:
+      {{- if .Values.extraInitContainers }}
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+      {{- end }}
       containers:
       - env:
         - name: LOGGING_LEVEL_ORG_HIBERNATE_SQL

--- a/reportportal/templates/index-deployment.yaml
+++ b/reportportal/templates/index-deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      initContainers:
+      {{- if .Values.extraInitContainers }}
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "reportportal.serviceAccountName" . }}
       containers:
       - env:

--- a/reportportal/templates/jobs-deployment.yaml
+++ b/reportportal/templates/jobs-deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      initContainers:
+      {{- if .Values.extraInitContainers }}
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+      {{- end }}
       containers:
       - env:
         - name: RP_ENVIRONMENT_VARIABLE_CLEAN_ATTACHMENT_CRON

--- a/reportportal/templates/metrics-gatherer-deployment.yaml
+++ b/reportportal/templates/metrics-gatherer-deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      initContainers:
+      {{- if .Values.extraInitContainers }}
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+      {{- end }}
       containers:
       - env:
         - name: RP_AMQP_PASS

--- a/reportportal/templates/uat-deployment.yaml
+++ b/reportportal/templates/uat-deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      initContainers:
+      {{- if .Values.extraInitContainers }}
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+      {{- end }}
       containers:
       - env:
         {{ if .Values.uat.jvmArgs }}

--- a/reportportal/templates/ui-deployment.yaml
+++ b/reportportal/templates/ui-deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      initContainers:
+      {{- if .Values.extraInitContainers }}
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+      {{- end }}
       containers:
       - env:
         - name: RP_SERVER_PORT

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -275,5 +275,5 @@ extraInitContainers: {}
   #   command:
   #     - sh
   #     - "-c"
-  #     - "for i in `seq 1 300`; do sleep 1; if wget http://<minio-endpoint>-minio:<minio-port>/minio/health/live -q -O /dev/null ; then exit 0; fi; done; exit 1"
+  #     - "for i in `seq 1 300`; do sleep 1; if wget http://<minio-release-name>.default.svc.cluster.local:9000/minio/health/live -q -O /dev/null ; then exit 0; fi; done; exit 1"
 

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -5,18 +5,6 @@
 ## String to fully override reportportal.fullname template
 ##
 # fullnameOverride:
-extraInitContainers: {}
-
-# Extra init containers to e.g. wait for minio
-#  - name: "wait-for-minio"
-#    image: "busybox"
-#    imagePullPolicy: "IfNotPresent"
-#    securityContext:
-#      runAsNonRoot: true
-#    command:
-#      - sh
-#      - "-c"
-#      - "for i in {1..100}; do sleep 1; if nc -vz <minio-endpoint> <minio-port>; then exit 0; fi; done; exit 1"
 
 serviceindex:
   name: index
@@ -278,3 +266,14 @@ rbac:
 rp:
   infoEndpoint: "/info"
   healthEndpoint: "/health"
+
+# Extra init containers to e.g. wait for minio
+extraInitContainers: {}
+  # - name: "wait-for-minio"
+  #   image: "busybox"
+  #   imagePullPolicy: "IfNotPresent"
+  #   command:
+  #     - sh
+  #     - "-c"
+  #     - "for i in `seq 1 300`; do sleep 1; if wget http://<minio-endpoint>-minio:<minio-port>/minio/health/live -q -O /dev/null ; then exit 0; fi; done; exit 1"
+

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -5,6 +5,18 @@
 ## String to fully override reportportal.fullname template
 ##
 # fullnameOverride:
+extraInitContainers: {}
+
+# Extra init containers to e.g. wait for minio
+#  - name: "wait-for-minio"
+#    image: "busybox"
+#    imagePullPolicy: "IfNotPresent"
+#    securityContext:
+#      runAsNonRoot: true
+#    command:
+#      - sh
+#      - "-c"
+#      - "for i in {1..100}; do sleep 1; if nc -vz <minio-endpoint> <minio-port>; then exit 0; fi; done; exit 1"
 
 serviceindex:
   name: index


### PR DESCRIPTION
This PR add the ability to configure init containers for all the pods (except the migration pod) .

This is usefull in case you need to wait the object store service or the database. 