### PR TITLE
allows to change the access-key and secret-key names in minio secret.

### DIFF
--- a/reportportal/README.md
+++ b/reportportal/README.md
@@ -642,10 +642,13 @@ minio:
   region:
   accesskey: <your_minio_accesskey>
   secretkey: <your_minio_secretkey>
+  accesskeyName: "access-key"
+  secretkeyName: "secret-key"
   bucketPrefix:
   defaultBucketName:
   integrationSaltPath:
 ```
+If you want to use a minio version newer than 9.0.0 change the `accesskeyName` to `"root-user"` and the `secretkeyName` to `"root-password"`.
 
 You can also use Amazon S3 storage instead of self-hosted MinIO's storage through passing S3 endpoint and IAM user access key ID and secret to the RP_BINARYSTORE_MINIO_* env variables, which can be defined via the same parameters in values.yaml.
 

--- a/reportportal/templates/analyzer-statefulset.yaml
+++ b/reportportal/templates/analyzer-statefulset.yaml
@@ -30,12 +30,12 @@ spec:
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.minio.secretName }}"
-              key: "access-key"
+              key: "{{ .Values.minio.accesskeyName }}"
         - name: MINIO_SECRET_KEY
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.minio.secretName }}"
-              key: "secret-key"
+              key: "{{ .Values.minio.secretkeyName }}"
        {{ else }}
         - name: MINIO_ACCESS_KEY
           value: "{{ .Values.minio.accesskey }}"

--- a/reportportal/templates/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/analyzertrain-statefulset.yaml
@@ -34,12 +34,12 @@ spec:
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.minio.secretName }}"
-              key: "access-key"
+              key: "{{ .Values.minio.accesskeyName }}"
         - name: MINIO_SECRET_KEY
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.minio.secretName }}"
-              key: "secret-key"
+              key: "{{ .Values.minio.secretkeyName }}"
        {{ else }}
         - name: MINIO_ACCESS_KEY
           value: "{{ .Values.minio.accesskey }}"

--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -105,12 +105,12 @@ spec:
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.minio.secretName }}"
-              key: "access-key"
+              key: "{{ .Values.minio.accesskeyName }}"
         - name: RP_BINARYSTORE_MINIO_SECRETKEY
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.minio.secretName }}"
-              key: "secret-key"
+              key: "{{ .Values.minio.secretkeyName }}"
        {{- else }}
         - name: RP_BINARYSTORE_MINIO_ACCESSKEY
           value: "{{ .Values.minio.accesskey }}"

--- a/reportportal/templates/jobs-deployment.yaml
+++ b/reportportal/templates/jobs-deployment.yaml
@@ -110,12 +110,12 @@ spec:
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.minio.secretName }}"
-              key: "access-key"
+              key: "{{ .Values.minio.accesskeyName }}"
         - name: DATASTORE_MINIO_SECRETKEY
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.minio.secretName }}"
-              key: "secret-key"
+              key: "{{ .Values.minio.secretkeyName }}"
        {{- else }}
         - name: DATASTORE_MINIO_ACCESSKEY
           value: "{{ .Values.minio.accesskey }}"

--- a/reportportal/templates/uat-deployment.yaml
+++ b/reportportal/templates/uat-deployment.yaml
@@ -60,12 +60,12 @@ spec:
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.minio.secretName }}"
-              key: "access-key"
+              key: "{{ .Values.minio.accesskeyName }}"
         - name: RP_BINARYSTORE_MINIO_SECRETKEY
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.minio.secretName }}"
-              key: "secret-key"
+              key: "{{ .Values.minio.secretkeyName }}"
         {{ else }}
         - name: RP_BINARYSTORE_MINIO_ACCESSKEY
           value: "{{ .Values.minio.accesskey }}"

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -267,6 +267,8 @@ minio:
   region: ""
   accesskey: <minio-accesskey>
   secretkey: <minio-secretkey>
+  accesskeyName: "access-key"
+  secretkeyName: "secret-key"
   bucketPrefix: ""
   defaultBucketName: ""
   integrationSaltPath: ""


### PR DESCRIPTION
newer versions of bitnami/minio store the access-key and secret-key
under different names in the predefined secret, namely 'root-user' and
'root-password'. This patch allows to change the key names in the
values.yaml accordingly.