### PR TITLE
Fix node selectors for deployments

### DIFF
--- a/reportportal/templates/index-deployment.yaml
+++ b/reportportal/templates/index-deployment.yaml
@@ -48,13 +48,13 @@ spec:
             memory: {{ .Values.serviceindex.resources.limits.memory }}
 {{- if .Values.serviceindex.nodeSelector }}
       nodeSelector:
-        {{- range $key, $value := .Values.nodeSelector }}
+        {{- range $key, $value := .Values.serviceindex.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
 {{- end }}
       securityContext:
 {{ toYaml .Values.serviceindex.securityContext | indent 8}}
 {{- with .Values.tolerations }}
-      tolerations: 
+      tolerations:
 {{- toYaml . | nindent 8 }}
 {{- end }}

--- a/reportportal/templates/migrations-job.yaml
+++ b/reportportal/templates/migrations-job.yaml
@@ -49,9 +49,9 @@ spec:
           limits:
             cpu: {{ .Values.migrations.resources.limits.cpu }}
             memory: {{ .Values.migrations.resources.limits.memory }}
-{{- if .Values.nodeSelector }}
+{{- if .Values.migrations.nodeSelector }}
       nodeSelector:
-        {{- range $key, $value := .Values.nodeSelector }}
+        {{- range $key, $value := .Values.migrations.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
 {{- end }}
@@ -60,6 +60,6 @@ spec:
       serviceAccountName: {{ .Values.migrations.serviceAccountName }}
 {{- end }}
 {{- with .Values.tolerations }}
-      tolerations: 
+      tolerations:
 {{- toYaml . | nindent 8 }}
 {{- end }}

--- a/reportportal/templates/ui-deployment.yaml
+++ b/reportportal/templates/ui-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           timeoutSeconds: 3
 {{- if .Values.serviceui.nodeSelector }}
       nodeSelector:
-        {{- range $key, $value := .Values.nodeSelector }}
+        {{- range $key, $value := .Values.serviceui.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
 {{- end }}
@@ -50,6 +50,6 @@ spec:
 {{ toYaml .Values.serviceui.securityContext | indent 8}}
       serviceAccountName: {{ .Values.serviceui.serviceAccountName }}
 {{- with .Values.tolerations }}
-      tolerations: 
+      tolerations:
 {{- toYaml . | nindent 8 }}
 {{- end }}


### PR DESCRIPTION
This PR is to fix incorrect keys used by helm to generate node selector fields in multiple deployments.