### PR TITLE
Release 5.7.0

### DIFF
--- a/reportportal/templates/analyzer-statefulset.yaml
+++ b/reportportal/templates/analyzer-statefulset.yaml
@@ -20,6 +20,9 @@ spec:
     spec:
       containers:
       - env:
+{{- if .Values.serviceanalyzer.extraEnvs }}
+{{ toYaml ( .Values.serviceanalyzer.extraEnvs ) | indent 8 }}
+{{- end }}
       {{ if .Values.minio.enabled }}
         - name: ANALYZER_BINARYSTORE_TYPE
           value: "minio"
@@ -57,14 +60,27 @@ spec:
         - name: AMQP_EXCHANGE_NAME
           value: "analyzer-default"
         - name: ES_HOSTS
-          value: "{{ .Values.elasticsearch.endpoint }}"
+          value: "http://{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
+        {{- if .Values.elasticsearch.secretName }}
+        - name: ES_USER
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.elasticsearch.secretName }}"
+              key: "username"
+        - name: ES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.elasticsearch.secretName }}"
+              key: "password"
+        {{- else }}
+        - name: ES_USER
+          value: "{{ .Values.elasticsearch.user }}"
+        - name: ES_PASSWORD
+          value: "{{ .Values.elasticsearch.password }}" 
+        {{- end }}
         {{- if .Values.serviceanalyzer.uwsgiWorkers }}
         - name: UWSGI_WORKERS
           value: "{{ .Values.serviceanalyzer.uwsgiWorkers }}"
-        {{- end }}
-        {{- range $key, $value := .Values.serviceanalyzer.additionalEnvironments }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
         {{- end }}
         image: "{{ .Values.serviceanalyzer.repository }}:{{ .Values.serviceanalyzer.tag }}"
         name: analyzer

--- a/reportportal/templates/analyzer-statefulset.yaml
+++ b/reportportal/templates/analyzer-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
         - name: AMQP_EXCHANGE_NAME
           value: "analyzer-default"
         - name: ES_HOSTS
-          value: "http://{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
+          value: "{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
         {{- if .Values.elasticsearch.secretName }}
         - name: ES_USER
           valueFrom:

--- a/reportportal/templates/analyzer-statefulset.yaml
+++ b/reportportal/templates/analyzer-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
         - name: AMQP_EXCHANGE_NAME
           value: "analyzer-default"
         - name: ES_HOSTS
-          value: "{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
+          value: "{{ .Values.elasticsearch.endpoint }}"
         {{- if .Values.elasticsearch.secretName }}
         - name: ES_USER
           valueFrom:

--- a/reportportal/templates/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/analyzertrain-statefulset.yaml
@@ -64,7 +64,7 @@ spec:
         - name: AMQP_EXCHANGE_NAME
           value: "analyzer-default"
         - name: ES_HOSTS
-          value: "http://{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
+          value: "{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
         {{- if .Values.elasticsearch.secretName }}
         - name: ES_USER
           valueFrom:

--- a/reportportal/templates/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/analyzertrain-statefulset.yaml
@@ -20,6 +20,9 @@ spec:
     spec:
       containers:
       - env:
+{{- if .Values.serviceanalyzertrain.extraEnvs }}
+{{ toYaml ( .Values.serviceanalyzertrain.extraEnvs ) | indent 8 }}
+{{- end }}
         - name: INSTANCE_TASK_TYPE
           value: "train"
         - name: UWSGI_WORKERS
@@ -61,7 +64,24 @@ spec:
         - name: AMQP_EXCHANGE_NAME
           value: "analyzer-default"
         - name: ES_HOSTS
-          value: "{{ .Values.elasticsearch.endpoint }}"
+          value: "http://{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
+        {{- if .Values.elasticsearch.secretName }}
+        - name: ES_USER
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.elasticsearch.secretName }}"
+              key: "username"
+        - name: ES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.elasticsearch.secretName }}"
+              key: "password"
+        {{- else }}
+        - name: ES_USER
+          value: "{{ .Values.elasticsearch.user }}"
+        - name: ES_PASSWORD
+          value: "{{ .Values.elasticsearch.password }}" 
+        {{- end }}
         image: "{{ .Values.serviceanalyzer.repository }}:{{ .Values.serviceanalyzer.tag }}"
         name: analyzer
         ports:

--- a/reportportal/templates/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/analyzertrain-statefulset.yaml
@@ -64,7 +64,7 @@ spec:
         - name: AMQP_EXCHANGE_NAME
           value: "analyzer-default"
         - name: ES_HOSTS
-          value: "{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
+          value: "{{ .Values.elasticsearch.endpoint }}"
         {{- if .Values.elasticsearch.secretName }}
         - name: ES_USER
           valueFrom:

--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -19,10 +19,9 @@ spec:
     spec:
       containers:
       - env:
-        {{- range $key, $value := .Values.serviceapi.additionalEnvironments }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
-        {{- end }}
+{{- if .Values.serviceapi.extraEnvs }}
+{{ toYaml ( .Values.serviceapi.extraEnvs ) | indent 8 }}
+{{- end }}
         - name: LOGGING_LEVEL_ORG_HIBERNATE_SQL
           value: "info"
         - name: RP_REQUESTLOGGING

--- a/reportportal/templates/index-deployment.yaml
+++ b/reportportal/templates/index-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             memory: {{ .Values.serviceindex.resources.limits.memory }}
 {{- if .Values.serviceindex.nodeSelector }}
       nodeSelector:
-        {{- range $key, $value := .Values.nodeSelector }}
+        {{- range $key, $value := .Values.serviceindex.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
 {{- end }}

--- a/reportportal/templates/jobs-deployment.yaml
+++ b/reportportal/templates/jobs-deployment.yaml
@@ -19,10 +19,9 @@ spec:
     spec:
       containers:
       - env:
-        {{- range $key, $value := .Values.servicejobs.additionalEnvironments }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
-        {{- end }}
+{{- if .Values.servicejobs.extraEnvs }}
+{{ toYaml ( .Values.servicejobs.extraEnvs ) | indent 8 }}
+{{- end }}
         - name: RP_ENVIRONMENT_VARIABLE_CLEAN_ATTACHMENT_CRON
           value: "{{ .Values.servicejobs.coreJobs.cleanAttachmentCron }}"
         - name: RP_ENVIRONMENT_VARIABLE_CLEAN_LOG_CRON

--- a/reportportal/templates/metrics-gatherer-deployment.yaml
+++ b/reportportal/templates/metrics-gatherer-deployment.yaml
@@ -19,6 +19,9 @@ spec:
     spec:
       containers:
       - env:
+{{- if .Values.metricsgatherer.extraEnvs }}
+{{ toYaml ( .Values.metricsgatherer.extraEnvs ) | indent 8 }}
+{{- end }}
         - name: RP_AMQP_PASS
         {{ if .Values.rabbitmq.SecretName }}
           valueFrom:
@@ -33,7 +36,24 @@ spec:
         - name: LOGGING_LEVEL
           value: "{{ .Values.metricsgatherer.loggingLevel }}"
         - name: ES_HOST
-          value: "{{ .Values.elasticsearch.endpoint }}"
+          value: "http://{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
+        {{- if .Values.elasticsearch.secretName }}
+        - name: ES_USER
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.elasticsearch.secretName }}"
+              key: "username"
+        - name: ES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.elasticsearch.secretName }}"
+              key: "password"
+        {{- else }}
+        - name: ES_USER
+          value: "{{ .Values.elasticsearch.user }}"
+        - name: ES_PASSWORD
+          value: "{{ .Values.elasticsearch.password }}" 
+        {{- end }}
         - name: POSTGRES_HOST
           value: "{{ .Values.postgresql.endpoint.address }}"
         - name: POSTGRES_PORT

--- a/reportportal/templates/metrics-gatherer-deployment.yaml
+++ b/reportportal/templates/metrics-gatherer-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - name: LOGGING_LEVEL
           value: "{{ .Values.metricsgatherer.loggingLevel }}"
         - name: ES_HOST
-          value: "{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
+          value: "{{ .Values.elasticsearch.endpoint }}"
         {{- if .Values.elasticsearch.secretName }}
         - name: ES_USER
           valueFrom:

--- a/reportportal/templates/metrics-gatherer-deployment.yaml
+++ b/reportportal/templates/metrics-gatherer-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - name: LOGGING_LEVEL
           value: "{{ .Values.metricsgatherer.loggingLevel }}"
         - name: ES_HOST
-          value: "http://{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
+          value: "{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
         {{- if .Values.elasticsearch.secretName }}
         - name: ES_USER
           valueFrom:

--- a/reportportal/templates/migrations-job.yaml
+++ b/reportportal/templates/migrations-job.yaml
@@ -51,7 +51,7 @@ spec:
           limits:
             cpu: {{ .Values.migrations.resources.limits.cpu }}
             memory: {{ .Values.migrations.resources.limits.memory }}
-{{- if .Values.nodeSelector }}
+{{- if .Values.migrations.nodeSelector }}
       nodeSelector:
         {{- range $key, $value := .Values.migrations.nodeSelector }}
         {{ $key }}: {{ $value | quote }}

--- a/reportportal/templates/uat-deployment.yaml
+++ b/reportportal/templates/uat-deployment.yaml
@@ -19,10 +19,9 @@ spec:
     spec:
       containers:
       - env:
-        {{- range $key, $value := .Values.uat.additionalEnvironments }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
-        {{- end }}
+{{- if .Values.uat.extraEnvs }}
+{{ toYaml ( .Values.uat.extraEnvs ) | indent 8 }}
+{{- end }}
         {{ if .Values.uat.jvmArgs }}
         - name: JAVA_OPTS
           value: "{{ .Values.uat.jvmArgs }}"

--- a/reportportal/templates/ui-deployment.yaml
+++ b/reportportal/templates/ui-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           timeoutSeconds: 3
 {{- if .Values.serviceui.nodeSelector }}
       nodeSelector:
-        {{- range $key, $value := .Values.nodeSelector }}
+        {{- range $key, $value := .Values.serviceui.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
 {{- end }}

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -20,11 +20,16 @@ serviceindex:
       memory: 256Mi
   podAnnotations: {}
   securityContext: {}
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  #  disktype: ssd
 
 uat:
   repository: reportportal/service-authorization
   name: uat
-  tag: 5.6.3
+  tag: 5.7.0
   pullPolicy: Always
   resources:
     requests:
@@ -36,20 +41,27 @@ uat:
   sessionLiveTime: 86400
   podAnnotations: {}
   jvmArgs: "-Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0"
-  ## Additional environment variables
+  ## External environment variables
   ##
-  additionalEnvironments: {}
-  #   env: value
+  extraEnvs: {}
+    # - name: EXTRA_ENV
+    #   value: "TRUE"
+    # - name: EXTRA_ENV_SECRET
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: "additional-credentials"
+    #       key: username
   securityContext: {}
   ## Define which Nodes the Pods are scheduled on.
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
+  #  disktype: ssd
   serviceAccountName: ""
 
 serviceui:
   repository: reportportal/service-ui
-  tag: 5.6.0
+  tag: 5.7.0
   name: ui
   pullPolicy: Always
   resources:
@@ -70,7 +82,7 @@ serviceui:
 
 serviceapi:
   repository: reportportal/service-api
-  tag: 5.6.3
+  tag: 5.7.0
   name: api
   pullPolicy: Always
   replicaCount: 1
@@ -90,10 +102,16 @@ serviceapi:
   queues:
     totalNumber:
     perPodNumber:
-  ## Additional environment variables
+  ## External environment variables
   ##
-  additionalEnvironments: {}
-  #  env: value
+  extraEnvs: {}
+    # - name: EXTRA_ENV
+    #   value: "TRUE"
+    # - name: EXTRA_ENV_SECRET
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: "additional-credentials"
+    #       key: username
   podAnnotations: {}
   securityContext: {}
   ## Define which Nodes the Pods are scheduled on.
@@ -105,7 +123,7 @@ serviceapi:
 
 servicejobs:
   repository: reportportal/service-jobs
-  tag: 5.6.3
+  tag: 5.7.0
   name: jobs
   pullPolicy: Always
   coreJobs:
@@ -123,10 +141,16 @@ servicejobs:
       cpu: 100m
       memory: 372Mi
   jvmArgs: ""
-  ## Additional environment variables
+  ## External environment variables
   ##
-  additionalEnvironments: {}
-  #  env: value
+  extraEnvs: {}
+    # - name: EXTRA_ENV
+    #   value: "TRUE"
+    # - name: EXTRA_ENV_SECRET
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: "additional-credentials"
+    #       key: username
   podAnnotations: {}
   securityContext: {}
   ## Define which Nodes the Pods are scheduled on.
@@ -138,7 +162,7 @@ servicejobs:
 
 migrations:
   repository: reportportal/migrations
-  tag: 5.6.0
+  tag: 5.7.0
   pullPolicy: Always
   resources:
     requests:
@@ -149,6 +173,9 @@ migrations:
       memory: 128Mi
   podAnnotations: {}
   securityContext: {}
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
   nodeSelector: {}
   #  disktype: ssd
   serviceAccountName: ""
@@ -160,7 +187,7 @@ migrations:
 
 serviceanalyzer:
   repository: reportportal/service-auto-analyzer
-  tag: 5.6.0
+  tag: 5.7.0
   name: analyzer
   pullPolicy: Always
   uwsgiWorkers: 2
@@ -173,10 +200,16 @@ serviceanalyzer:
       memory: 512Mi
   podAnnotations: {}
   securityContext: {}
-  ## Additional environment variables
+  ## External environment variables
   ##
-  additionalEnvironments: {}
-  #  ES_CHUNK_NUMBER: 2000
+  extraEnvs: {}
+    # - name: EXTRA_ENV
+    #   value: "TRUE"
+    # - name: EXTRA_ENV_SECRET
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: "additional-credentials"
+    #       key: username
   ##
   ## Define which Nodes the Pods are scheduled on.
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -195,6 +228,16 @@ serviceanalyzertrain:
       memory: 512Mi
   podAnnotations: {}
   securityContext: {}
+  ## External environment variables
+  ##
+  extraEnvs: {}
+    # - name: EXTRA_ENV
+    #   value: "TRUE"
+    # - name: EXTRA_ENV_SECRET
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: "additional-credentials"
+    #       key: username
   ## Define which Nodes the Pods are scheduled on.
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
@@ -221,6 +264,16 @@ metricsgatherer:
       memory: 256Mi
   podAnnotations: {}
   securityContext: {}
+  ## External environment variables
+  ##
+  extraEnvs: {}
+    # - name: EXTRA_ENV
+    #   value: "TRUE"
+    # - name: EXTRA_ENV_SECRET
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: "additional-credentials"
+    #       key: username
   ## Define which Nodes the Pods are scheduled on.
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
@@ -249,17 +302,21 @@ postgresql:
     port: 5432
     user: rpuser
     dbName: reportportal
-    ssl: disabled
     ## Whether or not to use SSL
+    ssl: disabled
     # ssl: disabled / require
     password:
     ## Number of database connections
     connections: 
 
 elasticsearch:
+  secretName: # "elasticsearch-credentials"
   installdep:
     enable: false
-  endpoint: http://elasticsearch-master:9200
+  endpoint: elasticsearch-master.default.svc.cluster.local
+  port: 9200
+  user: elastic
+  password:
 
 minio:
   secretName: ""

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -313,7 +313,7 @@ elasticsearch:
   secretName: ""
   installdep:
     enable: false
-  endpoint: elasticsearch-master.default.svc.cluster.local
+  endpoint: http://elasticsearch-master.default.svc.cluster.local
   port: 9200
   user: elastic
   password:

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -310,7 +310,7 @@ postgresql:
     connections: 
 
 elasticsearch:
-  secretName: # "elasticsearch-credentials"
+  secretName: ""
   installdep:
     enable: false
   endpoint: elasticsearch-master.default.svc.cluster.local

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -313,8 +313,7 @@ elasticsearch:
   secretName: ""
   installdep:
     enable: false
-  endpoint: http://elasticsearch-master.default.svc.cluster.local
-  port: 9200
+  endpoint: http://elasticsearch-master.default.svc.cluster.local:9200
   user: elastic
   password:
 


### PR DESCRIPTION
## Release 5.7.0

### Changes
- Updated `extraEnvs`. More flexibility than before

reportportal/values.yaml
```yaml
 ## External environment variables
 ##
  extraEnvs: {}
    # - name: EXTRA_ENV
    #   value: "TRUE"
    # - name: EXTRA_ENV_SECRET
    #   valueFrom:
    #     secretKeyRef:
    #       name: "additional-credentials"
    #       key: username
```


reportportal/templates/*-deployment.yaml
```yaml
{{- if .Values.metricsgatherer.extraEnvs }}
{{ toYaml ( .Values.metricsgatherer.extraEnvs ) | indent 8 }}
{{- end }}
```

- Updated Elasticsearch values. Added possibility of using Secrets and Login/Password for ElasticSearch.
- Updated Kubernetes DNS path to ElasticSearch host.

reportportal/values.yaml
```yaml
 elasticsearch:
  secretName: ""
  installdep:
    enable: false
  endpoint: elasticsearch-master.default.svc.cluster.local
  port: 9200
  user: elastic
  password:
```

reportportal/templates/*-statefulsets.yaml
```yaml
- name: ES_HOSTS
  value: "http://{{ .Values.elasticsearch.endpoint }}:{{ .Values.elasticsearch.port }}"
{{- if .Values.elasticsearch.secretName }}
- name: ES_USER
  valueFrom:
    secretKeyRef:
      name: "{{ .Values.elasticsearch.secretName }}"
      key: "username"
- name: ES_PASSWORD
  valueFrom:
    secretKeyRef:
      name: "{{ .Values.elasticsearch.secretName }}"
      key: "password"
{{- else }}
- name: ES_USER
  value: "{{ .Values.elasticsearch.user }}"
- name: ES_PASSWORD
  value: "{{ .Values.elasticsearch.password }}" 
{{- end }}
```


- Updated `NodeSelector` for other services.
- Release 5.7.0


---
⚠️ **All changes tested on beta environment**

- Expample `extraEnvs`

reportportal/values.yaml

<img width="552" alt="image" src="https://user-images.githubusercontent.com/50049166/163999467-fde5a2b5-f968-4cc0-a545-570c18a0c73e.png">

kubectl describe pod

<img width="1114" alt="image" src="https://user-images.githubusercontent.com/50049166/163999671-b2608960-22ad-4611-bece-d5a6e0eb4baa.png">

- Example ElasticSearch changes for Analyzer, Analyzer Train and Metrics Gatherer

<img width="941" alt="image" src="https://user-images.githubusercontent.com/50049166/164000310-c56ca0b3-2936-4cb3-87fb-22e339256771.png">
