### PR TITLE
extraEnvs improvements

### DIFF
--- a/reportportal/templates/analyzer-statefulset.yaml
+++ b/reportportal/templates/analyzer-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - env:
 {{- if .Values.serviceanalyzer.extraEnvs }}
-{{ toYaml ( .Values.serviceanalyzer.extraEnvs ) | indent 8 }}
+{{ toYaml .Values.serviceanalyzer.extraEnvs | indent 8 }}
 {{- end }}
       {{ if .Values.minio.enabled }}
         - name: ANALYZER_BINARYSTORE_TYPE

--- a/reportportal/templates/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/analyzertrain-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - env:
 {{- if .Values.serviceanalyzertrain.extraEnvs }}
-{{ toYaml ( .Values.serviceanalyzertrain.extraEnvs ) | indent 8 }}
+{{ toYaml .Values.serviceanalyzertrain.extraEnvs | indent 8 }}
 {{- end }}
         - name: INSTANCE_TASK_TYPE
           value: "train"

--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - env:
 {{- if .Values.serviceapi.extraEnvs }}
-{{ toYaml ( .Values.serviceapi.extraEnvs ) | indent 8 }}
+{{ toYaml .Values.serviceapi.extraEnvs | indent 8 }}
 {{- end }}
         - name: LOGGING_LEVEL_ORG_HIBERNATE_SQL
           value: "info"

--- a/reportportal/templates/jobs-deployment.yaml
+++ b/reportportal/templates/jobs-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - env:
 {{- if .Values.servicejobs.extraEnvs }}
-{{ toYaml ( .Values.servicejobs.extraEnvs ) | indent 8 }}
+{{ toYaml .Values.servicejobs.extraEnvs | indent 8 }}
 {{- end }}
         - name: RP_ENVIRONMENT_VARIABLE_CLEAN_ATTACHMENT_CRON
           value: "{{ .Values.servicejobs.coreJobs.cleanAttachmentCron }}"

--- a/reportportal/templates/metrics-gatherer-deployment.yaml
+++ b/reportportal/templates/metrics-gatherer-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - env:
 {{- if .Values.metricsgatherer.extraEnvs }}
-{{ toYaml ( .Values.metricsgatherer.extraEnvs ) | indent 8 }}
+{{ toYaml .Values.metricsgatherer.extraEnvs | indent 8 }}
 {{- end }}
         - name: RP_AMQP_PASS
         {{ if .Values.rabbitmq.SecretName }}

--- a/reportportal/templates/uat-deployment.yaml
+++ b/reportportal/templates/uat-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - env:
 {{- if .Values.uat.extraEnvs }}
-{{ toYaml ( .Values.uat.extraEnvs ) | indent 8 }}
+{{ toYaml .Values.uat.extraEnvs | indent 8 }}
 {{- end }}
         {{ if .Values.uat.jvmArgs }}
         - name: JAVA_OPTS

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -43,7 +43,7 @@ uat:
   jvmArgs: "-Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0"
   ## External environment variables
   ##
-  extraEnvs: {}
+  extraEnvs: []
     # - name: EXTRA_ENV
     #   value: "TRUE"
     # - name: EXTRA_ENV_SECRET
@@ -104,7 +104,7 @@ serviceapi:
     perPodNumber:
   ## External environment variables
   ##
-  extraEnvs: {}
+  extraEnvs: []
     # - name: EXTRA_ENV
     #   value: "TRUE"
     # - name: EXTRA_ENV_SECRET
@@ -143,7 +143,7 @@ servicejobs:
   jvmArgs: ""
   ## External environment variables
   ##
-  extraEnvs: {}
+  extraEnvs: []
     # - name: EXTRA_ENV
     #   value: "TRUE"
     # - name: EXTRA_ENV_SECRET
@@ -202,7 +202,7 @@ serviceanalyzer:
   securityContext: {}
   ## External environment variables
   ##
-  extraEnvs: {}
+  extraEnvs: []
     # - name: EXTRA_ENV
     #   value: "TRUE"
     # - name: EXTRA_ENV_SECRET
@@ -230,7 +230,7 @@ serviceanalyzertrain:
   securityContext: {}
   ## External environment variables
   ##
-  extraEnvs: {}
+  extraEnvs: []
     # - name: EXTRA_ENV
     #   value: "TRUE"
     # - name: EXTRA_ENV_SECRET
@@ -266,7 +266,7 @@ metricsgatherer:
   securityContext: {}
   ## External environment variables
   ##
-  extraEnvs: {}
+  extraEnvs: []
     # - name: EXTRA_ENV
     #   value: "TRUE"
     # - name: EXTRA_ENV_SECRET


### PR DESCRIPTION
Minor fixes to `extraEnvs` values to reduce the warnings.

```
coalesce.go:220: warning: cannot overwrite table with non table for (map[])
```