### PR TITLE
Allow overriding service port names in values.yaml to better support Istio Gateway

### DIFF
--- a/reportportal/templates/analyzer-service.yaml
+++ b/reportportal/templates/analyzer-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels: {{ include "labels" . | indent 4 }}
 spec:
   ports:
-  - name: headless
+  - name: {{ $.Values.serviceanalyzer.service.portName | default "headless" }}
     port: 8080
     protocol: TCP
     targetPort: 8080

--- a/reportportal/templates/analyzertrain-service.yaml
+++ b/reportportal/templates/analyzertrain-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels: {{ include "labels" . | indent 4 }}
 spec:
   ports:
-  - name: headless
+  - name: {{ $.Values.serviceanalyzertrain.service.portName | default "headless" }}
     port: 5000
     protocol: TCP
     targetPort: 5000

--- a/reportportal/templates/api-service.yaml
+++ b/reportportal/templates/api-service.yaml
@@ -8,7 +8,7 @@ metadata:
     infoEndpoint: {{ $.Values.rp.infoEndpoint | default "/info"}}
 spec:
   ports:
-  - name: headless
+  - name: {{ $.Values.serviceapi.service.portName | default "headless" }}
     port: 8585
     protocol: TCP
     targetPort: 8585

--- a/reportportal/templates/gateway-ingress-legacy.yaml
+++ b/reportportal/templates/gateway-ingress-legacy.yaml
@@ -24,19 +24,19 @@ spec:
       - path: /()?(.*)
         backend:
           serviceName: {{ $fullName }}-index
-          servicePort: headless
+          servicePort: {{ $.Values.serviceindex.service.portName | default "headless" }}
       - path: /(ui)/?(.*)
         backend:
           serviceName: {{ $fullName }}-ui
-          servicePort: headless
+          servicePort: {{ $.Values.serviceui.service.portName | default "headless" }}
       - path: /(uat)/?(.*)
         backend:
           serviceName: {{ $fullName }}-uat
-          servicePort: headless
+          servicePort: {{ $.Values.uat.service.portName | default "headless" }}
       - path: /(api)/?(.*)
         backend:
           serviceName: {{ $fullName }}-api
-          servicePort: headless
+          servicePort: {{ $.Values.serviceapi.service.portName | default "headless" }}
   {{- end -}}
 {{ else }}
   - http:
@@ -44,19 +44,19 @@ spec:
       - path: /()?(.*)
         backend:
           serviceName: {{ $fullName }}-index
-          servicePort: headless
+          servicePort: {{ $.Values.serviceindex.service.portName | default "headless" }}
       - path: /(ui)/?(.*)
         backend:
           serviceName: {{ $fullName }}-ui
-          servicePort: headless
+          servicePort: {{ $.Values.serviceui.service.portName | default "headless" }}
       - path: /(uat)/?(.*)
         backend:
           serviceName: {{ $fullName }}-uat
-          servicePort: headless
+          servicePort: {{ $.Values.uat.service.portName | default "headless" }}
       - path: /(api)/?(.*)
         backend:
           serviceName: {{ $fullName }}-api
-          servicePort: headless
+          servicePort: {{ $.Values.serviceapi.service.portName | default "headless" }}
 {{ end }}
 status:
   loadBalancer: {}

--- a/reportportal/templates/gateway-ingress.yaml
+++ b/reportportal/templates/gateway-ingress.yaml
@@ -27,28 +27,28 @@ spec:
           service:
             name: {{ $fullName }}-index
             port:
-              name: headless
+              name: {{ $.Values.serviceindex.service.portName | default "headless" }}
       - path: /(ui)/?(.*)
         pathType: Prefix
         backend:
           service:
             name: {{ $fullName }}-ui
             port:
-              name: headless
+              name: {{ $.Values.serviceui.service.portName | default "headless" }}
       - path: /(uat)/?(.*)
         pathType: Prefix
         backend:
           service:
             name: {{ $fullName }}-uat
             port:
-              name: headless
+              name: {{ $.Values.uat.service.portName | default "headless" }}
       - path: /(api)/?(.*)
         pathType: Prefix
         backend:
           service:
             name: {{ $fullName }}-api
             port:
-              name: headless
+              name: {{ $.Values.serviceapi.service.portName | default "headless" }}
   {{- end -}}
 {{ else }}
   - http:
@@ -59,28 +59,28 @@ spec:
           service:
             name: {{ $fullName }}-index
             port:
-              name: headless
+              name: {{ $.Values.serviceindex.service.portName | default "headless" }}
       - path: /(ui)/?(.*)
         pathType: Prefix
         backend:
           service:
             name: {{ $fullName }}-ui
             port:
-              name: headless
+              name: {{ $.Values.serviceui.service.portName | default "headless" }}
       - path: /(uat)/?(.*)
         pathType: Prefix
         backend:
           service:
             name: {{ $fullName }}-uat
             port:
-              name: headless
+              name: {{ $.Values.uat.service.portName | default "headless" }}
       - path: /(api)/?(.*)
         pathType: Prefix
         backend:
           service:
             name: {{ $fullName }}-api
             port:
-              name: headless
+              name: {{ $.Values.serviceapi.service.portName | default "headless" }}
 {{ end }}
 status:
   loadBalancer: {}

--- a/reportportal/templates/index-service.yaml
+++ b/reportportal/templates/index-service.yaml
@@ -8,7 +8,7 @@ metadata:
     infoEndpoint: {{ $.Values.rp.infoEndpoint | default "/info"}}
 spec:
   ports:
-  - name: headless
+  - name: {{ $.Values.serviceindex.service.portName | default "headless" }}
     port: 8080
     protocol: TCP
     targetPort: 8080

--- a/reportportal/templates/jobs-services.yaml
+++ b/reportportal/templates/jobs-services.yaml
@@ -8,7 +8,7 @@ metadata:
     infoEndpoint: {{ $.Values.rp.infoEndpoint | default "/info"}}
 spec:
   ports:
-  - name: headless
+  - name: {{ $.Values.servicejobs.service.portName | default "headless" }}
     port: 8686
     protocol: TCP
     targetPort: 8686

--- a/reportportal/templates/metrics-gatherer-service.yaml
+++ b/reportportal/templates/metrics-gatherer-service.yaml
@@ -8,7 +8,7 @@ metadata:
     infoEndpoint: {{ $.Values.rp.infoEndpoint | default "/info"}}
 spec:
   ports:
-  - name: headless
+  - name: {{ $.Values.metricsgatherer.service.portName | default "headless" }}
     port: 8585
     protocol: TCP
     targetPort: 8585

--- a/reportportal/templates/uat-service.yaml
+++ b/reportportal/templates/uat-service.yaml
@@ -8,7 +8,7 @@ metadata:
     infoEndpoint: {{ $.Values.rp.infoEndpoint | default "/info"}}
 spec:
   ports:
-  - name: headless
+  - name: {{ $.Values.uat.service.portName | default "headless" }}
     port: 9999
     protocol: TCP
     targetPort: 9999

--- a/reportportal/templates/ui-service.yaml
+++ b/reportportal/templates/ui-service.yaml
@@ -8,7 +8,7 @@ metadata:
     infoEndpoint: {{ $.Values.rp.infoEndpoint | default "/info"}}
 spec:
   ports:
-  - name: headless
+  - name: {{ $.Values.serviceui.service.portName | default "headless" }}
     port: 8080
     protocol: TCP
     targetPort: 8080

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -25,6 +25,8 @@ serviceindex:
   ##
   nodeSelector: {}
   #  disktype: ssd
+  service:
+    portName: {}
 
 uat:
   repository: reportportal/service-authorization
@@ -76,6 +78,8 @@ uat:
     readOnly: true
     data: {}
     #  custom-pki.jks: <base64-data>
+  service:
+    portName: headless
 
 serviceui:
   repository: reportportal/service-ui
@@ -97,6 +101,8 @@ serviceui:
   nodeSelector: {}
   #  disktype: ssd
   serviceAccountName: ""
+  service:
+    portName: {}
 
 serviceapi:
   repository: reportportal/service-api
@@ -138,6 +144,8 @@ serviceapi:
   nodeSelector: {}
   #  disktype: ssd
   serviceAccountName: ""
+  service:
+    portName: {}
 
 servicejobs:
   repository: reportportal/service-jobs
@@ -177,6 +185,8 @@ servicejobs:
   nodeSelector: {}
   #  disktype: ssd
   serviceAccountName: ""
+  service:
+    portName: {}
 
 migrations:
   repository: reportportal/migrations
@@ -235,6 +245,8 @@ serviceanalyzer:
   nodeSelector: {}
   #  disktype: ssd
   serviceAccountName: ""
+  service:
+    portName: {}
 
 serviceanalyzertrain:
   resources:
@@ -262,6 +274,8 @@ serviceanalyzertrain:
   nodeSelector: {}
   #  disktype: ssd
   serviceAccountName: ""
+  service:
+    portName: {}
 
 metricsgatherer:
   repository: reportportal/service-metrics-gatherer
@@ -298,6 +312,8 @@ metricsgatherer:
   nodeSelector: {}
   #  disktype: ssd
   serviceAccountName: ""
+  service:
+    portName: {}
 
 rabbitmq:
   SecretName: ""

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -79,7 +79,7 @@ uat:
     data: {}
     #  custom-pki.jks: <base64-data>
   service:
-    portName: headless
+    portName: {}
 
 serviceui:
   repository: reportportal/service-ui

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -26,7 +26,7 @@ serviceindex:
   nodeSelector: {}
   #  disktype: ssd
   service:
-    portName: {}
+    portName: ""
 
 uat:
   repository: reportportal/service-authorization
@@ -79,7 +79,7 @@ uat:
     data: {}
     #  custom-pki.jks: <base64-data>
   service:
-    portName: {}
+    portName: ""
 
 serviceui:
   repository: reportportal/service-ui
@@ -102,7 +102,7 @@ serviceui:
   #  disktype: ssd
   serviceAccountName: ""
   service:
-    portName: {}
+    portName: ""
 
 serviceapi:
   repository: reportportal/service-api
@@ -145,7 +145,7 @@ serviceapi:
   #  disktype: ssd
   serviceAccountName: ""
   service:
-    portName: {}
+    portName: ""
 
 servicejobs:
   repository: reportportal/service-jobs
@@ -186,7 +186,7 @@ servicejobs:
   #  disktype: ssd
   serviceAccountName: ""
   service:
-    portName: {}
+    portName: ""
 
 migrations:
   repository: reportportal/migrations
@@ -246,7 +246,7 @@ serviceanalyzer:
   #  disktype: ssd
   serviceAccountName: ""
   service:
-    portName: {}
+    portName: ""
 
 serviceanalyzertrain:
   resources:
@@ -275,7 +275,7 @@ serviceanalyzertrain:
   #  disktype: ssd
   serviceAccountName: ""
   service:
-    portName: {}
+    portName: ""
 
 metricsgatherer:
   repository: reportportal/service-metrics-gatherer
@@ -313,7 +313,7 @@ metricsgatherer:
   #  disktype: ssd
   serviceAccountName: ""
   service:
-    portName: {}
+    portName: ""
 
 rabbitmq:
   SecretName: ""


### PR DESCRIPTION
This pr is to address [issue 253](https://github.com/reportportal/kubernetes/issues/253): **Ability to override service names in service definition to match Istio naming conventions**

I did do one thing slightly different than originally discussed: 
`Values.<service name>.service.portName` instead of `Values.<service name>.portName`. 

I thought the nesting made it clearer it was for the service configuration but if thats not desirable I'll change it back.

The ingress templates were updated as well to use the same overridden values.