### PR TITLE
Release/5.7.2

### DIFF
--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -135,6 +135,8 @@ spec:
           value: "{{ .Values.minio.integrationSaltPath }}"
        {{- end }}
        {{- end }}
+        - name: MANAGEMENT_HEALTH_ELASTICSEARCH_ENABLED
+          value: "false"
         image: "{{ .Values.serviceapi.repository }}:{{ .Values.serviceapi.tag }}"
         name: api
         ports:

--- a/reportportal/templates/jobs-deployment.yaml
+++ b/reportportal/templates/jobs-deployment.yaml
@@ -128,6 +128,12 @@ spec:
           value: "{{ .Values.minio.secretkey }}"
        {{- end }}
        {{ end }}
+        - name: RP_PROCESSING_LOG_MAXBATCHSIZE
+          value: "2000"
+        - name: RP_PROCESSING_LOG_MAXBATCHTIMEOUT
+          value: "6000"
+        - name: RP_AMQP_MAXLOGCONSUMER
+          value: "1"
         image: "{{ .Values.servicejobs.repository }}:{{ .Values.servicejobs.tag }}"
         name: jobs
         ports:

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -395,6 +395,10 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "8000"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "4000"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "4000"
+  tls: []
+  # - hosts:
+  #   - reportportal.k8.com
+  #   secretName: reportportal.k8.com-tls
 
 # tolerations for all components, if any (requires Kubernetes >= 1.6)
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -83,7 +83,7 @@ uat:
 
 serviceui:
   repository: reportportal/service-ui
-  tag: 5.7.0
+  tag: 5.7.2
   name: ui
   pullPolicy: Always
   resources:
@@ -106,7 +106,7 @@ serviceui:
 
 serviceapi:
   repository: reportportal/service-api
-  tag: 5.7.1
+  tag: 5.7.2
   name: api
   pullPolicy: Always
   replicaCount: 1
@@ -152,7 +152,7 @@ serviceapi:
 
 servicejobs:
   repository: reportportal/service-jobs
-  tag: 5.7.1
+  tag: 5.7.2
   name: jobs
   pullPolicy: Always
   coreJobs:
@@ -218,7 +218,7 @@ migrations:
 
 serviceanalyzer:
   repository: reportportal/service-auto-analyzer
-  tag: 5.7.1
+  tag: 5.7.2
   name: analyzer
   pullPolicy: Always
   uwsgiWorkers: 2
@@ -282,7 +282,7 @@ serviceanalyzertrain:
 
 metricsgatherer:
   repository: reportportal/service-metrics-gatherer
-  tag: 1.1.19
+  tag: 1.1.20
   name: metrics-gatherer
   loggingLevel: debug
   timeManagement:


### PR DESCRIPTION
## Release 5.7.2

### New Environments
**JOBS**
```YAML
# Perfomance configs
- name: RP_PROCESSING_LOG_MAXBATCHSIZE
  value: "2000"
- name: RP_PROCESSING_LOG_MAXBATCHTIMEOUT
  value: "6000"
- name: RP_AMQP_MAXLOGCONSUMER
  value: "1"
```

**API**
```YAML
# For double entry
- name: MANAGEMENT_HEALTH_ELASTICSEARCH_ENABLED
  value: "false"
```

### Ingres TLS
https://github.com/reportportal/kubernetes/issues/263 

```YAML
ingress:
  <...>
  tls: []
  # - hosts:
  #   - reportportal.k8.com
  #   secretName: reportportal.k8.com-tls
```

### Relese: 
```
reportportal/service-api:5.7.2
reportportal/service-ui:5.7.2
reportportal/service-metrics-gatherer:1.1.20
reportportal/service-auto-analyzer:5.7.2 
reportportal/service-jobs:5.7.2
```