### PR TITLE
add istio ingress options

### DIFF
--- a/reportportal/templates/gateway-istio.yaml
+++ b/reportportal/templates/gateway-istio.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.istio.gateway.create }}
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: {{ .Values.ingress.istio.gateway.name }}
+spec:
+  selector:
+    {{ .Values.ingress.istio.gateway.selector }}
+  servers:
+  - hosts:
+    {{- range $host := .Values.ingress.hosts }}
+    - {{ $host }}
+    {{- end }}
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+    {{- if .Values.ingress.istio.gateway.tls.enable }}
+    tls:
+      httpsRedirect: true
+    {{- end }}
+  {{- if .Values.ingress.istio.gateway.tls.enable }}
+  - hosts:
+    {{- range $host := .Values.ingress.hosts }}
+    - {{ $host }}
+    {{- end }}
+    port:
+      name: https
+      number: 443
+      protocol: HTTPS
+    tls:
+      credentialName: {{ .Values.ingress.istio.gateway.tls.credentialname }}
+      mode: SIMPLE
+  {{- end }}
+{{- end }}

--- a/reportportal/templates/virtualService.yaml
+++ b/reportportal/templates/virtualService.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.ingress.istio.enable }}
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ .Values.ingress.istio.virtualservice.name }}
+spec:
+  gateways:
+  {{- if .Values.ingress.istio.gateway.externalnamespace }}
+  - {{.Values.ingress.istio.gateway.externalnamespace }}/{{ .Values.ingress.istio.gateway.name }}
+  {{- else }}
+  - {{ .Values.ingress.istio.gateway.name }}
+  {{- end }}
+  {{- range $host := .Values.ingress.hosts }}
+  hosts:
+  - {{ $host }}
+  {{- end }}
+  http:
+  - match:
+    - uri:
+        prefix: /api/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: {{ .Release.Name }}-reportportal-api.{{ .Release.Namespace }}.svc.cluster.local
+        port:
+          number: 8585
+  - match:
+    - uri:
+        prefix: /uat/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: {{ .Release.Name }}-reportportal-uat.{{ .Release.Namespace }}.svc.cluster.local
+        port:
+          number: 9999
+  - match:
+    - uri:
+        prefix: /ui/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: {{ .Release.Name }}-reportportal-ui.{{ .Release.Namespace }}.svc.cluster.local
+        port:
+          number: 8080
+  - route:
+    - destination:
+        host: {{ .Release.Name }}-reportportal-index.{{ .Release.Namespace }}.svc.cluster.local
+        port:
+          number: 8080
+{{- end }}

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -400,6 +400,24 @@ ingress:
   #   - reportportal.k8.com
   #   secretName: reportportal.k8.com-tls
 
+  # If you wish to use istio ingress gateways
+  # set ingress.enable to false
+  # set ingress.istio.enable true
+  # configure hostnames with ingress.hosts[]
+  istio:
+    enable: false
+    gateway:
+      # Set create to true if you wish to create the gateway
+      create: false
+      name: reportportal-gateway
+      selector: "istio: ingressgateway"
+      # Set tls enable to true if you wish the gateway to use tls
+      tls:
+        enable: false
+        credentialname: istio-system-reportportal
+    virtualservice:
+      name: reportportal-vs
+
 # tolerations for all components, if any (requires Kubernetes >= 1.6)
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 tolerations: []


### PR DESCRIPTION
Taking @nabbott2008 virtualservice from https://github.com/reportportal/kubernetes/issues/185, and adding it as an option to the chart.

Fix some typos in the README.md
move around some information to make it clear ingress isn't the only option.

Would love more feedback on the README.md changes and where to place the values, I figured under ingress would make sense, could argue for moving it to its own block if you wanted to.