### PR TITLE
Adding ability to add a secret for serviceapi

### DIFF
--- a/reportportal/templates/api-deployment.yaml
+++ b/reportportal/templates/api-deployment.yaml
@@ -161,6 +161,12 @@ spec:
           failureThreshold: {{ .Values.serviceapi.livenessProbe.failureThreshold | default 5 }}
         {{- end }}
         {{- end }}
+        volumeMounts:
+          {{- if .Values.serviceapi.secret.enabled }}
+          - mountPath: {{ .Values.serviceapi.secret.mountPath }}
+            name: {{ template "reportportal.name" . }}-serviceapi-secret
+            readOnly: {{ .Values.serviceapi.secret.readOnly }}
+          {{- end }}
 {{- if .Values.serviceapi.nodeSelector }}
       nodeSelector:
         {{- range $key, $value := .Values.serviceapi.nodeSelector }}
@@ -174,3 +180,9 @@ spec:
       tolerations:
 {{- toYaml . | nindent 8 }}
 {{- end }}
+      volumes:
+        {{- if .Values.serviceapi.secret.enabled }}
+        - name: {{ template "reportportal.name" . }}-serviceapi-secret
+          secret:
+            secretName: {{ template "reportportal.name" . }}-serviceapi-secret
+        {{- end }}

--- a/reportportal/templates/api-secret.yaml
+++ b/reportportal/templates/api-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.serviceapi.secret.enabled .Values.serviceapi.secret.data -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "reportportal.name" . }}-serviceapi-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+data:
+{{ toYaml .Values.serviceapi.secret.data | indent 2 }}
+{{- end}}

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -144,6 +144,9 @@ serviceapi:
     limits:
       cpu: 1000m
       memory: 2048Mi
+  ## jvmArgs
+  ## If you need to use a custom java keystore you can use it through jvmArgs
+  ## eg. : -Djavax.net.ssl.trustStore=/etc/secret-volume/custom-pki.jks 
   jvmArgs: "-Djava.security.egd=file:/dev/./urandom -XX:+UseG1GC -XX:MinRAMPercentage=60.0 -XX:InitiatingHeapOccupancyPercent=70 -XX:MaxRAMPercentage=90.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
   ## Number of queues
   ## Where "totalNumber" is the total number of queues
@@ -172,6 +175,21 @@ serviceapi:
   serviceAccountName: ""
   service:
     portName: ""
+  ## Provide a secret containing sensitives data
+  ## eg. : provide a custom java keystore used in jvmArgs
+  ##
+  ## keytool -genkeypair -storetype jks -alias todelete -keypass changeit -storepass changeit -keystore custom-pki.jks -dname "CN=Developer, OU=Department, O=Company, L=City, ST=State, C=CA"
+  ## keytool -delete -alias todelete -storepass changeit -keystore custom-pki.jks
+  ## keytool -list -keystore custom-pki.jks -storepass changeit
+  ## 
+  ## Generate base64 data and paste it in your values.yaml :
+  ## cat custom-pki.jks | base64 -w 
+  secret:
+    enabled: false
+    mountPath: /etc/secret-volume
+    readOnly: true
+    data: {}
+    #  custom-pki.jks: <base64-data>
 
 servicejobs:
   repository: reportportal/service-jobs


### PR DESCRIPTION
Adding ability to add a secret for serviceapi: this is usefull in case users configure SMTP over SSL and the SMTP host use a certificate signed by a private PKI.