### PR TITLE
Allow skip of migrations job

### DIFF
--- a/templates/service-migrations/migrations-job.yaml
+++ b/templates/service-migrations/migrations-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.migrations.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -70,4 +71,5 @@ spec:
 {{- with .Values.tolerations }}
       tolerations: 
 {{- toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -423,6 +423,7 @@ metricsgatherer:
     extraPorts: []
 
 migrations:
+  enabled: true
   image:
     repository: reportportal/migrations
     tag: 5.10.1


### PR DESCRIPTION
For a clean install, trying to run migrations at all should be skipped. This allows `--set migrations.enabled=false` at chart install time to skip unwanted migrations for this kind of deployment.