### PR TITLE
Restore ability to skip migrations job for new/clean install

### DIFF
--- a/templates/service-migrations/migrations-job.yaml
+++ b/templates/service-migrations/migrations-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.migrations.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -70,4 +71,5 @@ spec:
 {{- with .Values.tolerations }}
       tolerations: 
 {{- toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/templates/service-migrations/migrations-job.yaml
+++ b/templates/service-migrations/migrations-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.migrations.enabled -}}
+{{- if or (not (hasKey .Values.migrations "enabled")) .Values.migrations.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -423,7 +423,6 @@ metricsgatherer:
     extraPorts: []
 
 migrations:
-  enabled: true
   image:
     repository: reportportal/migrations
     tag: 5.10.1

--- a/values.yaml
+++ b/values.yaml
@@ -423,6 +423,7 @@ metricsgatherer:
     extraPorts: []
 
 migrations:
+  enabled: true
   image:
     repository: reportportal/migrations
     tag: 5.10.1


### PR DESCRIPTION
The current latest chart (5.10) has the ability to set Values.migrations.enabled=false to skip this job, however the current development branch seems to have removed this.