### PR TITLE
Feature/add service annoations

### DIFF
--- a/reportportal/templates/service-api/api-service.yaml
+++ b/reportportal/templates/service-api/api-service.yaml
@@ -4,10 +4,12 @@ metadata:
   name: {{ include "reportportal.fullname" . }}-api
   labels: {{ include "labels" . | indent 4 }}
   annotations:
-{{ toYaml .Values.serviceapi.service.annotations | indent 4 }}
     service: {{ $.Values.serviceapi.name | default "api" }}
     infoEndpoint: "/api/info"
     healthEndpoint: "/api/health"
+{{- with .Values.serviceapi.service.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: {{ $.Values.serviceapi.service.type | default "ClusterIP" }}
   ports:

--- a/reportportal/templates/service-api/api-service.yaml
+++ b/reportportal/templates/service-api/api-service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "reportportal.fullname" . }}-api
   labels: {{ include "labels" . | indent 4 }}
   annotations:
+{{ toYaml .Values.serviceapi.service.annotations | indent 4 }}
     service: {{ $.Values.serviceapi.name | default "api" }}
     infoEndpoint: "/api/info"
     healthEndpoint: "/api/health"

--- a/reportportal/templates/service-authorization/uat-service.yaml
+++ b/reportportal/templates/service-authorization/uat-service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "reportportal.fullname" . }}-uat
   labels: {{ include "labels" . | indent 4 }}
   annotations:
+{{ toYaml .Values.uat.service.annotations | indent 4 }}
     service: {{ $.Values.uat.name | default "uat" }}
     infoEndpoint: "/uat/info"
     healthEndpoint: "/uat/health"

--- a/reportportal/templates/service-authorization/uat-service.yaml
+++ b/reportportal/templates/service-authorization/uat-service.yaml
@@ -4,10 +4,12 @@ metadata:
   name: {{ include "reportportal.fullname" . }}-uat
   labels: {{ include "labels" . | indent 4 }}
   annotations:
-{{ toYaml .Values.uat.service.annotations | indent 4 }}
     service: {{ $.Values.uat.name | default "uat" }}
     infoEndpoint: "/uat/info"
     healthEndpoint: "/uat/health"
+{{- with .Values.uat.service.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: {{ $.Values.uat.service.type | default "ClusterIP"}}
   ports:

--- a/reportportal/templates/service-index/index-service.yaml
+++ b/reportportal/templates/service-index/index-service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "reportportal.fullname" . }}-index
   labels: {{ include "labels" . | indent 4 }}
   annotations:
+{{ toYaml .Values.serviceindex.service.annotations | indent 4 }}
     service: {{ $.Values.serviceindex.name | default "index" }}
     infoEndpoint: "/info"
     healthEndpoint: "/health"

--- a/reportportal/templates/service-index/index-service.yaml
+++ b/reportportal/templates/service-index/index-service.yaml
@@ -4,10 +4,12 @@ metadata:
   name: {{ include "reportportal.fullname" . }}-index
   labels: {{ include "labels" . | indent 4 }}
   annotations:
-{{ toYaml .Values.serviceindex.service.annotations | indent 4 }}
     service: {{ $.Values.serviceindex.name | default "index" }}
     infoEndpoint: "/info"
     healthEndpoint: "/health"
+{{- with .Values.serviceindex.service.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: {{ $.Values.serviceindex.service.type | default "ClusterIP" }}
   ports:

--- a/reportportal/templates/service-ui/ui-service.yaml
+++ b/reportportal/templates/service-ui/ui-service.yaml
@@ -4,10 +4,12 @@ metadata:
   name: {{ include "reportportal.fullname" . }}-ui
   labels: {{ include "labels" . | indent 4 }}
   annotations:
-{{ toYaml .Values.serviceui.service.annotations | indent 4 }}
     service: {{ $.Values.serviceui.name | default "ui" }}
     infoEndpoint: "/ui/info"
     healthEndpoint: "/ui/health"
+{{- with .Values.serviceui.service.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: {{ $.Values.serviceui.service.type | default "ClusterIP"}}
   ports:

--- a/reportportal/templates/service-ui/ui-service.yaml
+++ b/reportportal/templates/service-ui/ui-service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "reportportal.fullname" . }}-ui
   labels: {{ include "labels" . | indent 4 }}
   annotations:
+{{ toYaml .Values.serviceui.service.annotations | indent 4 }}
     service: {{ $.Values.serviceui.name | default "ui" }}
     infoEndpoint: "/ui/info"
     healthEndpoint: "/ui/health"

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -33,6 +33,7 @@ serviceindex:
     portName: ""
     nodePort: ""
     extraPorts: []
+    annotations: {}
 
 serviceui:
   name: ui
@@ -61,6 +62,7 @@ serviceui:
     portName: ""
     nodePort: ""
     extraPorts: []
+    annotations: {}
 
 serviceapi:
   name: api
@@ -147,6 +149,7 @@ serviceapi:
     portName: ""
     nodePort: ""
     extraPorts: []
+    annotations: {}
 
   ## Provide a secret containing sensitives data
   ## e.g. provide a custom java keystore used in jvmArgs:
@@ -241,6 +244,7 @@ uat:
     portName: ""
     nodePort: ""
     extraPorts: []
+    annotations: {}
 
 servicejobs:
   name: jobs


### PR DESCRIPTION
Closes #359 .
I have added annotation support to `api`, `uat`, `index` and `ui` services.  
Should I add this to the remaining services as well?