### PR TITLE
FEATURE : Add full support for imagePullSecrets

### DIFF
--- a/reportportal/templates/service-index/index-deployment.yaml
+++ b/reportportal/templates/service-index/index-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       {{- if .Values.extraInitContainers }}
 {{ toYaml .Values.extraInitContainers | indent 8 }}

--- a/reportportal/templates/service-migrations/migrations-job.yaml
+++ b/reportportal/templates/service-migrations/migrations-job.yaml
@@ -18,6 +18,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       containers:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       - env:
         - name: POSTGRES_SSLMODE
           value: "{{ .Values.database.ssl }}"

--- a/reportportal/templates/service-ui/ui-deployment.yaml
+++ b/reportportal/templates/service-ui/ui-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       {{- if .Values.extraInitContainers }}
 {{ toYaml .Values.extraInitContainers | indent 8 }}

--- a/reportportal/templates/statefullset-auto-analyzer/metrics-gatherer-deployment.yaml
+++ b/reportportal/templates/statefullset-auto-analyzer/metrics-gatherer-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: migrations-waiting-init
         image: "{{ .Values.k8sWaitFor.image.repository }}:{{ .Values.k8sWaitFor.image.tag }}"

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -5,6 +5,9 @@
 nameOverride: ""
 fullnameOverride: ""
 
+global:
+  imagePullSecrets: []
+
 serviceindex:
   name: index
   image:
@@ -609,6 +612,7 @@ postgresql:
     registry: docker.io
     repository: bitnami/postgresql
     tag: 11.22.0
+    pullSecrets: []
   postgresqlUsername: *dbuser
   postgresqlPassword: *dbpassword
   postgresqlDatabase: *dbname
@@ -622,6 +626,7 @@ rabbitmq:
     registry: docker.io
     repository: bitnami/rabbitmq
     tag: 3.10.25
+    pullSecrets: []
   auth:
     username: *msgbrokerUser
     password: *msgbrokerPass
@@ -635,6 +640,7 @@ opensearch:
   image:
     repository: opensearchproject/opensearch
     tag: 2.11.1
+  imagePullSecrets: []
   ## @param opensearch.singleNode If "true", replicas will be forced from 3 to 1
   singleNode: true
   ## @param opensearch.httpPort Port for OpenSearch endpoint
@@ -655,6 +661,7 @@ minio:
     registry: docker.io
     repository: bitnami/minio
     tag: 2021.4.22-debian-10-r6
+    pullSecrets: []
   accessKey:
     password: *storageAccessKey
   secretKey:


### PR DESCRIPTION
It seems that currently only some of the ReportPortal Deployments and StatefulSets support **imagePullSecrets** which may be required in some cases to pull images from private registries. From what I can see it needs to also be supported for the dependent Helm charts below:
```
minio
opensearch
postgresql
rabbitmq
```
These changes should ensure **imagePullSecrets** can be applied to all ReportPortal components and all components required in the dependent charts.