### PR TITLE
Added missing vars in serviceapi and clusterDomain var

### DIFF
--- a/reportportal/templates/service-api/api-deployment.yaml
+++ b/reportportal/templates/service-api/api-deployment.yaml
@@ -68,7 +68,7 @@ spec:
         - name: SERVER_SERVLET_CONTEXT_PATH
           value: "{{ $path }}/api"
         - name: RP_JOBS_BASEURL
-          value: {{ ternary "https" "http" .Values.k8s.networking.ssl }}://{{ include "reportportal.fullname" . }}-jobs{{ printf ".%s.svc.cluster.local" .Release.Namespace }}:8686/jobs
+          value: {{ ternary "https" "http" .Values.k8s.networking.ssl }}://{{ include "reportportal.fullname" . }}-jobs.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8686/jobs
         - name: COM_TA_REPORTPORTAL_JOB_INTERRUPT_BROKEN_LAUNCHES_CRON
           value: "{{ .Values.serviceapi.cronJobs.interruptBrockenLaunches }}"
         - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_BATCH-SIZE
@@ -85,7 +85,7 @@ spec:
           value: "{{ .Values.serviceapi.allowDeleteAccount }}"
         {{- if .Values.searchengine.doubleEntry.enable }}
         - name: RP_ELASTICSEARCH_HOST
-          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.cluster.local" .Release.Namespace) }}:{{ .Values.searchengine.port }}"
+          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.%s" .Release.Namespace .Values.clusterDomain) }}:{{ .Values.searchengine.port }}"
         {{- if .Values.searchengine.secretName }}
         - name: RP_ELASTICSEARCH_USERNAME
           valueFrom:
@@ -128,11 +128,11 @@ spec:
           value: "{{ .Values.msgbroker.password }}"
         {{- end }}
         - name: RP_AMQP_API_ADDRESS
-          value: {{ ternary "https" "http" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.apiuser }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.apiport }}/api
+          value: {{ ternary "https" "http" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.apiuser }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.msgbroker.apiport }}/api
         - name: RP_AMQP_ADDRESSES
-          value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}'
+          value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.msgbroker.port }}'
         - name: RP_DB_HOST
-          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}
         - name: RP_DB_PORT
           value: "{{ .Values.database.port }}"
         - name: RP_DB_NAME
@@ -160,7 +160,7 @@ spec:
           value: "{{ .Values.storage.type }}"
         {{- if eq .Values.storage.type "minio" }}
         - name: DATASTORE_ENDPOINT
-          value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.storage.port }}"
+          value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.storage.port }}"
         {{- end }}
         {{- if .Values.storage.region }}
         - name: DATASTORE_REGION

--- a/reportportal/templates/service-api/api-deployment.yaml
+++ b/reportportal/templates/service-api/api-deployment.yaml
@@ -86,7 +86,24 @@ spec:
         {{- if .Values.searchengine.doubleEntry.enable }}
         - name: RP_ELASTICSEARCH_HOST
           value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.cluster.local" .Release.Namespace) }}:{{ .Values.searchengine.port }}"
-        {{- end }}
+        {{- if .Values.searchengine.secretName }}
+        - name: RP_ELASTICSEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.searchengine.secretName }}"
+              key: "username"
+        - name: RP_ELASTICSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.searchengine.secretName }}"
+              key: "password"
+        {{- else }}
+        - name: RP_ELASTICSEARCH_USERNAME
+          value: "{{ .Values.searchengine.user }}"
+        - name: RP_ELASTICSEARCH_PASSWORD
+          value: "{{ .Values.searchengine.password }}"
+        {{- end}}
+        {{- end}}
         - name: LOGGING_LEVEL_ORG_HIBERNATE_SQL
           value: "info"
         - name: RP_REQUESTLOGGING

--- a/reportportal/templates/service-authorization/uat-deployment.yaml
+++ b/reportportal/templates/service-authorization/uat-deployment.yaml
@@ -83,7 +83,7 @@ spec:
           value: "{{ .Values.msgbroker.password }}"
         {{- end }}
         - name: RP_AMQP_ADDRESSES
-          value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}'
+          value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.msgbroker.port }}'
         {{- if .Values.uat.superadminInitPasswd.secretName }}
         - name: RP_INITIAL_ADMIN_PASSWORD
           valueFrom:
@@ -103,7 +103,7 @@ spec:
         - name: RP_SESSION_LIVE
           value: "{{ .Values.uat.sessionLiveTime }}"
         - name: RP_DB_HOST
-          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}
         - name: RP_DB_PORT
           value: "{{ .Values.database.port }}"
         - name: RP_DB_NAME
@@ -127,7 +127,7 @@ spec:
           value: "{{ .Values.storage.type }}"
         {{- if eq .Values.storage.type "minio" }}
         - name: DATASTORE_ENDPOINT
-          value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.storage.port }}"
+          value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.storage.port }}"
         {{- end }}
         {{- if .Values.storage.region }}
         - name: DATASTORE_REGION

--- a/reportportal/templates/service-jobs/jobs-deployment.yaml
+++ b/reportportal/templates/service-jobs/jobs-deployment.yaml
@@ -64,7 +64,7 @@ spec:
           value: "/jobs"
         {{- if .Values.searchengine.doubleEntry.enable }}
         - name: RP_ELASTICSEARCH_HOST
-          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.cluster.local" .Release.Namespace) }}:{{ .Values.searchengine.port }}"
+          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.%s" .Release.Namespace .Values.clusterDomain) }}:{{ .Values.searchengine.port }}"
         {{- if .Values.searchengine.secretName }}
         - name: RP_ELASTICSEARCH_USERNAME
           valueFrom:
@@ -115,11 +115,11 @@ spec:
           value: "{{ .Values.msgbroker.password }}"
         {{- end }}
         - name: RP_AMQP_API_ADDRESS
-          value: {{ ternary "https" "http" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.apiuser }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.apiport }}/api
+          value: {{ ternary "https" "http" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.apiuser }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.msgbroker.apiport }}/api
         - name: RP_AMQP_ADDRESSES
-          value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}'
+          value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.msgbroker.port }}'
         - name: RP_DB_HOST
-          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}
         - name: RP_DB_PORT
           value: "{{ .Values.database.port }}"
         - name: RP_DB_NAME
@@ -147,7 +147,7 @@ spec:
           value: "{{ .Values.storage.type }}"
         {{- if eq .Values.storage.type "minio" }}
         - name: DATASTORE_ENDPOINT
-          value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.storage.port }}"
+          value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.storage.port }}"
         {{- end }}
         {{- if .Values.storage.region }}
         - name: DATASTORE_REGION

--- a/reportportal/templates/service-migrations/migrations-job.yaml
+++ b/reportportal/templates/service-migrations/migrations-job.yaml
@@ -26,7 +26,7 @@ spec:
         - name: POSTGRES_SSLMODE
           value: "{{ .Values.database.ssl }}"
         - name: POSTGRES_SERVER
-          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}
         - name: POSTGRES_DB
           value: "{{ .Values.database.dbName }}"
         - name: POSTGRES_PORT
@@ -43,7 +43,7 @@ spec:
           value: "{{ .Values.database.password }}"
         {{ end }}
         - name: OS_HOST
-          value: "{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.cluster.local" .Release.Namespace) }}"
+          value: "{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.%s" .Release.Namespace .Values.clusterDomain) }}"
         - name: OS_PORT
           value: "{{ .Values.searchengine.port | default "9200" }}"
         - name: OS_PROTOCOL

--- a/reportportal/templates/statefullset-auto-analyzer/analyzer-statefulset.yaml
+++ b/reportportal/templates/statefullset-auto-analyzer/analyzer-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
         - name: ANALYZER_BINARYSTORE_BUCKETPREFIX
           value: "{{ .Values.storage.bucket.bucketMultiPrefix }}"
         - name: MINIO_SHORT_HOST
-          value: "{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.storage.port }}"
+          value: "{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.storage.port }}"
         {{- if .Values.storage.secretName }}
         - name: MINIO_ACCESS_KEY
           valueFrom:
@@ -98,13 +98,13 @@ spec:
           value: "{{ .Values.msgbroker.password }}"
         {{- end }}
         - name: AMQP_URL
-          value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}/
+          value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.msgbroker.port }}/
         - name: AMQP_EXCHANGE_NAME
           value: "{{ .Values.msgbroker.analyzerExchangeName | default "analyzer-default" }}"
         - name: AMQP_VIRTUAL_HOST
           value: "{{ .Values.msgbroker.vhost }}"
         - name: ES_HOSTS
-          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.cluster.local" .Release.Namespace) }}:{{ .Values.searchengine.port }}"
+          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.%s" .Release.Namespace .Values.clusterDomain) }}:{{ .Values.searchengine.port }}"
         {{- if .Values.searchengine.secretName }}
         - name: ES_USER
           valueFrom:

--- a/reportportal/templates/statefullset-auto-analyzer/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/statefullset-auto-analyzer/analyzertrain-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
         - name: ANALYZER_BINARYSTORE_BUCKETPREFIX
           value: "{{ .Values.storage.bucket.bucketMultiPrefix }}"
         - name: MINIO_SHORT_HOST
-          value: "{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.storage.port }}"
+          value: "{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.storage.port }}"
         {{- if .Values.storage.secretName }}
         - name: MINIO_ACCESS_KEY
           valueFrom:
@@ -102,13 +102,13 @@ spec:
           value: "{{ .Values.msgbroker.password }}"
         {{- end }}
         - name: AMQP_URL
-          value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}/
+          value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.msgbroker.port }}/
         - name: AMQP_EXCHANGE_NAME
           value: "{{ .Values.msgbroker.analyzerExchangeName | default "analyzer-default" }}"
         - name: AMQP_VIRTUAL_HOST
           value: "{{ .Values.msgbroker.vhost }}"
         - name: ES_HOSTS
-          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.cluster.local" .Release.Namespace) }}:{{ .Values.searchengine.port }}"
+          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.%s" .Release.Namespace .Values.clusterDomain) }}:{{ .Values.searchengine.port }}"
         {{- if .Values.searchengine.secretName }}
         - name: ES_USER
           valueFrom:

--- a/reportportal/templates/statefullset-auto-analyzer/metrics-gatherer-deployment.yaml
+++ b/reportportal/templates/statefullset-auto-analyzer/metrics-gatherer-deployment.yaml
@@ -69,13 +69,13 @@ spec:
           value: "{{ .Values.msgbroker.password }}"
         {{ end }}
         - name: AMQP_URL
-          value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}/
+          value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}:{{ .Values.msgbroker.port }}/
         - name: AMQP_VIRTUAL_HOST
           value: "{{ .Values.msgbroker.vhost }}"
         - name: LOGGING_LEVEL
           value: "{{ .Values.metricsgatherer.loggingLevel }}"
         - name: ES_HOST
-          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.cluster.local" .Release.Namespace) }}:{{ .Values.searchengine.port }}"
+          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.%s" .Release.Namespace .Values.clusterDomain) }}:{{ .Values.searchengine.port }}"
         {{- if .Values.searchengine.secretName }}
         - name: ES_USER
           valueFrom:
@@ -94,7 +94,7 @@ spec:
           value: "{{ .Values.searchengine.password }}" 
         {{- end }}
         - name: POSTGRES_HOST
-          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.%s" .Release.Name .Release.Namespace .Values.clusterDomain) }}
         - name: POSTGRES_PORT
           value: "{{ .Values.database.port }}"
         - name: POSTGRES_DB

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -5,7 +5,7 @@
 nameOverride: ""
 fullnameOverride: ""
 
-clusterDomain: cluster.test
+clusterDomain: &clusterDomain cluster.1
 
 serviceindex:
   name: index
@@ -678,6 +678,7 @@ rabbitmq:
   containerPorts:
     amqp: *msgbrokerPort
     manager: *msgbrokerApiPort
+  clusterDomain: *clusterDomain
 
 ## @param opensearch External OpenSearch Helm Chart as dependency
 opensearch:

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -5,6 +5,8 @@
 nameOverride: ""
 fullnameOverride: ""
 
+clusterDomain: cluster.test
+
 serviceindex:
   name: index
   image:

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -5,7 +5,7 @@
 nameOverride: ""
 fullnameOverride: ""
 
-clusterDomain: &clusterDomain cluster.1
+clusterDomain: &clusterDomain cluster.local
 
 serviceindex:
   name: index


### PR DESCRIPTION
Motivation:
- For cluserDomain I use in my workaround cluster with different DNS name, also I think many companies use different domain, so It would be useful
- I've found that in Chart is missing credentials for ES/OS in serviceapi, I've copied variables from service jobs

Referenced issue: [2255](https://github.com/reportportal/reportportal/issues/2255)