### PR TITLE
Add persistent volume storge support

### DIFF
--- a/docs/gke-install.md
+++ b/docs/gke-install.md
@@ -125,9 +125,12 @@ For more information about creating a cluster in Autopilot mode you can find
 
 For a standard cluster you need to specify a machine type and a number of nodes.
 
-ReportPortal requires at least 3 nodes with 2 vCPU and 4 GB memory for each.
-We recommend using `custom-2-4096` machine type with 2 vCPU and 4 GB memory as
-a base configuration.
+ReportPortal requires at least 3 nodes with 4 vCPU and 6 GB memory for each in
+the Kubernetes with infrastructure dependencies.
+We recommend using `custom-4-6144` machine type with 4 vCPU and 6 GB memory
+as a minimal configuration.
+
+```bash
 
 If you want avoid using MinIO or Google Cloud Storage, you can use a filesystem storage type
 and Google Filestore as a storage class.
@@ -135,6 +138,8 @@ and Google Filestore as a storage class.
 For this, you need to enable the `Google Filestore CSI driver` when creating a cluster:
 
 ```bash
+export MACHINE_TYPE=custom-4-6144
+
 gcloud container clusters create ${CLUSTER_NAME} \
   --addons=GcpFilestoreCsiDriver \
   --zone=${LOCATION} \

--- a/docs/gke-install.md
+++ b/docs/gke-install.md
@@ -113,6 +113,11 @@ gcloud container clusters create-auto ${CLUSTER_NAME} \
   --location=${LOCATION}
 ```
 
+> **Note:** You can use the Google Filestore CSI driver for the Autopilot cluster.
+> It is enabled by default.
+> Minimal storage size for Google Filestore is 1 TB.
+> Check the [pricing](https://cloud.google.com/filestore/pricing).
+
 For more information about creating a cluster in Autopilot mode you can find
 [here](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-an-autopilot-cluster).
 
@@ -121,16 +126,31 @@ For more information about creating a cluster in Autopilot mode you can find
 For a standard cluster you need to specify a machine type and a number of nodes.
 
 ReportPortal requires at least 3 nodes with 2 vCPU and 4 GB memory for each.
-We recommend using `e2-standard-2` machine type with 2 vCPU and 8 GB memory:
+We recommend using `custom-2-4096` machine type with 2 vCPU and 4 GB memory as
+a base configuration.
+
+If you want avoid using MinIO or Google Cloud Storage, you can use a filesystem storage type
+and Google Filestore as a storage class.
+
+For this, you need to enable the `Google Filestore CSI driver` when creating a cluster:
 
 ```bash
-export MACHINE_TYPE=e2-standard-2
-
 gcloud container clusters create ${CLUSTER_NAME} \
+  --addons=GcpFilestoreCsiDriver \
   --zone=${LOCATION} \
-  --machine-type=${MACHINE_TYPE} \
-  --num-nodes=3
+  --machine-type=${MACHINE_TYPE}
 ```
+
+or you can enable it after the cluster creation:
+
+```bash
+gcloud container clusters update ${CLUSTER_NAME} \
+  --update-addons=GcpFilestoreCsiDriver=ENABLED
+```
+
+> **Note:**
+> Minimal storage size for Google Filestore is 1 TB.
+> Check the [pricing](https://cloud.google.com/filestore/pricing).
 
 More information about creating a cluster in Standard mode you can find
 [here](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-zonal-cluster#gcloud).
@@ -235,6 +255,30 @@ helm install \
   --version ${VERSION}
 ```
 
+If you want to use Google Filestore instead of MinIO, you need to set
+the `storage.type` to `filesystem`, `storage.volume.storageClassName`
+to `standard-rwx`, and disable MinIO installation:
+
+```bash
+helm install \
+  --set ingress.class="gce" \
+  --set uat.superadminInitPasswd.password=${SUPERADMIN_PASSWORD} \
+  --set uat.resources.requests.memory="1Gi" \
+  --set serviceapi.resources.requests.cpu="1000m" \
+  --set serviceapi.resources.requests.memory="2Gi" \
+  --set serviceanalyzer.resources.requests.memory="1Gi" \
+  --set storage.type="filesystem" \
+  --set storage.volume.storageClassName="standard-rwx" \
+  --set minio.install=false \
+  ${RELEASE_NAME} \
+  oci://${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/reportportal \
+  --version ${VERSION}
+```
+
+> **Note:**
+> Minimal storage size for Google Filestore is 1 TB.
+> Check the [pricing](https://cloud.google.com/filestore/pricing).
+
 ### Install Helm chart on GKE Standard Cluster
 
 For installing ReportPortal on GKE Standard Cluster you need to set:
@@ -250,6 +294,26 @@ helm install \
   oci://${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/reportportal \
   --version ${VERSION}
 ```
+
+If you want to use Google Filestore instead of MinIO, you need to set
+the `storage.type` to `filesystem`, `storage.volume.storageClassName`
+to `standard-rwx`, and disable MinIO installation:
+
+```bash
+helm install \
+  --set ingress.class="gce" \
+  --set uat.superadminInitPasswd.password=${SUPERADMIN_PASSWORD} \
+  --set storage.type="filesystem" \
+  --set storage.volume.storageClassName="standard-rwx" \
+  --set minio.install=false \
+  ${RELEASE_NAME} \
+  oci://${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/reportportal \
+  --version ${VERSION}
+```
+
+> **Note:**
+> Minimal storage size for Google Filestore is 1 TB.
+> Check the [pricing](https://cloud.google.com/filestore/pricing).
 
 ## Ingress configuration
 

--- a/docs/minikube-install.md
+++ b/docs/minikube-install.md
@@ -3,6 +3,7 @@
 - [Install ReportPortal on Minikube](#install-reportportal-on-minikube)
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
+    - [Overview](#overview)
     - [Start Minikube](#start-minikube)
     - [Set up hostnames](#set-up-hostnames)
     - [Install ReportPortal](#install-reportportal)
@@ -18,6 +19,17 @@
 - [Helm](https://helm.sh/docs/intro/install/)
 
 ## Installation
+
+### Overview
+
+In this guide, we will install ReportPortal on Minikube using Helm with
+ReportPortal's services and the following dependencies:
+
+- PostgreSQL
+- OpenSearch
+- RabbitMQ
+
+Instead of Minio, we will use a Persistent Volume as a filesystem storage.
 
 ### Start Minikube
 
@@ -46,7 +58,9 @@ export SUPERADMIN_PASSWORD=superadmin
 
 helm install reportportal \
   reportportal/reportportal \
-  --set uat.superadminInitPasswd.password=${SUPERADMIN_PASSWORD}
+  --set uat.superadminInitPasswd.password=${SUPERADMIN_PASSWORD} \
+  --set storage.type=filesystem \
+  --set minio.install=false
 ```
 
 #### Install from GitHub repo

--- a/docs/minikube-install.md
+++ b/docs/minikube-install.md
@@ -6,6 +6,8 @@
     - [Start Minikube](#start-minikube)
     - [Set up hostnames](#set-up-hostnames)
     - [Install ReportPortal](#install-reportportal)
+      - [Install from Helm repo](#install-from-helm-repo)
+      - [Install from GitHub repo](#install-from-github-repo)
     - [Access ReportPortal](#access-reportportal)
   - [Clean up](#clean-up)
 
@@ -62,7 +64,9 @@ export SUPERADMIN_PASSWORD=superadmin
 
 helm install reportportal \
   ./reportportal \
-  --set uat.superadminInitPasswd.password=${SUPERADMIN_PASSWORD}
+  --set uat.superadminInitPasswd.password=${SUPERADMIN_PASSWORD} \
+  --set storage.type=filesystem \
+  --set minio.install=false
 ```
 
 ### Access ReportPortal

--- a/docs/minikube-install.md
+++ b/docs/minikube-install.md
@@ -63,12 +63,20 @@ helm install reportportal \
   --set minio.install=false
 ```
 
+If you want to use Minio as a storage:
+
+```bash
+helm install reportportal \
+  reportportal/reportportal \
+  --set uat.superadminInitPasswd.password=${SUPERADMIN_PASSWORD}
+```
+
 #### Install from GitHub repo
 
 Call the following commands from the downloaded [kubernetes](https://github.com/reportportal/kubernetes/) repository.
 
 ```bash
-# Dowload the chart dependencies
+# Download the chart dependencies
 helm dependency build ./reportportal 
 ```
 
@@ -81,6 +89,14 @@ helm install reportportal \
   --set uat.superadminInitPasswd.password=${SUPERADMIN_PASSWORD} \
   --set storage.type=filesystem \
   --set minio.install=false
+```
+
+If you want to use Minio as a storage:
+
+```bash
+helm install reportportal \
+  ./reportportal \
+  --set uat.superadminInitPasswd.password=${SUPERADMIN_PASSWORD}
 ```
 
 ### Access ReportPortal

--- a/docs/minikube-install.md
+++ b/docs/minikube-install.md
@@ -66,6 +66,8 @@ helm install reportportal \
 If you want to use Minio as a storage:
 
 ```bash
+export SUPERADMIN_PASSWORD=superadmin
+
 helm install reportportal \
   reportportal/reportportal \
   --set uat.superadminInitPasswd.password=${SUPERADMIN_PASSWORD}
@@ -73,7 +75,8 @@ helm install reportportal \
 
 #### Install from GitHub repo
 
-Call the following commands from the downloaded [kubernetes](https://github.com/reportportal/kubernetes/) repository.
+Call the following commands from the downloaded
+[kubernetes](https://github.com/reportportal/kubernetes/) repository.
 
 ```bash
 # Download the chart dependencies

--- a/reportportal/templates/service-api/api-deployment.yaml
+++ b/reportportal/templates/service-api/api-deployment.yaml
@@ -1,5 +1,4 @@
 {{- $path := .Values.ingress.path -}}
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -91,14 +90,15 @@ spec:
           value: "info"
         - name: RP_REQUESTLOGGING
           value: "false"
-        - name: RP_AMQP_QUEUES
-          value: {{ .Values.serviceapi.queues.totalNumber | default "10" | quote }}
-        - name: RP_AMQP_QUEUESPERPOD
-          value: {{ .Values.serviceapi.queues.perPodNumber | default "10" | quote }}
         {{- if .Values.serviceapi.jvmArgs }}
         - name: JAVA_OPTS
           value: "{{ .Values.serviceapi.jvmArgs }}"
         {{- end }}
+        # AMQP settings
+        - name: RP_AMQP_QUEUES
+          value: {{ .Values.serviceapi.queues.totalNumber | default "10" | quote }}
+        - name: RP_AMQP_QUEUESPERPOD
+          value: {{ .Values.serviceapi.queues.perPodNumber | default "10" | quote }}
         - name: RP_AMQP_ANALYZER-VHOST
           value: "{{ .Values.msgbroker.vhost }}"
         - name: RP_AMQP_PASS
@@ -113,7 +113,8 @@ spec:
         - name: RP_AMQP_API_ADDRESS
           value: {{ ternary "https" "http" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.apiuser }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.apiport }}/api
         - name: RP_AMQP_ADDRESSES
-          value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}'
+          value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}
+        # Database settings
         - name: RP_DB_HOST
           value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
         - name: RP_DB_PORT
@@ -135,12 +136,9 @@ spec:
         {{- else }}
           value: "{{ .Values.database.password }}"
         {{- end }}
-        {{- if eq .Values.storage.bucket.type "single" }}
-        - name: RP_FEATURE_FLAGS
-          value: "singleBucket"
-        {{- end }}
         - name: DATASTORE_TYPE
           value: "{{ .Values.storage.type }}"
+        {{- if or (eq .Values.storage.type "minio") (eq .Values.storage.type "s3") }}
         {{- if eq .Values.storage.type "minio" }}
         - name: DATASTORE_ENDPOINT
           value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.storage.port }}"
@@ -160,22 +158,27 @@ spec:
             secretKeyRef:
               name: "{{ .Values.storage.secretName }}"
               key: "{{ .Values.storage.secretkeyName }}"
-       {{- else }}
+        {{- else }}
         - name: DATASTORE_ACCESSKEY
           value: "{{ .Values.storage.accesskey }}"
         - name: DATASTORE_SECRETKEY
           value: "{{ .Values.storage.secretkey }}"
-       {{- end }}
-       {{- if eq .Values.storage.bucket.type "multi" }}
+        {{- end }}
+        {{- if eq .Values.storage.bucket.type "single" }}
+        - name: RP_FEATURE_FLAGS
+          value: "singleBucket"
+        {{- end }}
+        {{- if eq .Values.storage.bucket.type "multi" }}
         - name: DATASTORE_BUCKETPREFIX
           value: "{{ .Values.storage.bucket.bucketMultiPrefix }}"
         - name: DATASTORE_BUCKETPOSTFIX
           value: "{{ .Values.storage.bucket.bucketMultiPostfix }}"
         - name: RP_INTEGRATION_SALT_PATH
           value: "{{ .Values.storage.bucket.bucketMultiSaltName }}"
-       {{- end }}
+        {{- end }}
         - name: DATASTORE_DEFAULTBUCKETNAME
           value: "{{ .Values.storage.bucket.bucketDefaultName }}"
+        {{- end }}
         - name: MANAGEMENT_HEALTH_ELASTICSEARCH_ENABLED
           value: "false"
         {{- if .Values.serviceapi.readinessProbe.enabled }}
@@ -200,13 +203,17 @@ spec:
         {{- end }}
         volumeMounts:
           {{- if .Values.serviceapi.secret.enabled }}
-          - mountPath: {{ .Values.serviceapi.secret.mountPath }}
-            name: {{ template "reportportal.name" . }}-serviceapi-secret
+          - name: {{ template "reportportal.name" . }}-serviceapi-secret
+            mountPath: {{ .Values.serviceapi.secret.mountPath }}
             readOnly: {{ .Values.serviceapi.secret.readOnly }}
           {{- end }}
           {{- if .Values.serviceapi.auditLogs.enable }}
           - name: audit-log-volume
             mountPath: /var/log
+          {{- end }}
+          {{- if eq .Values.storage.type "filesystem" }}
+          - name: shared-volume
+            mountPath: /data/storage
           {{- end }}
       {{- if .Values.serviceapi.auditLogs.enable }}
       - name: auditlogstreamer
@@ -244,4 +251,9 @@ spec:
         {{- if .Values.serviceapi.auditLogs.enable }}
         - name: audit-log-volume
           emptyDir: {}
+        {{- end }}
+        {{- if eq .Values.storage.type "filesystem" }}
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-shared-volume-claim
         {{- end }}

--- a/reportportal/templates/service-api/api-deployment.yaml
+++ b/reportportal/templates/service-api/api-deployment.yaml
@@ -21,239 +21,243 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
-      {{- with .Values.serviceapi.hostAliases }}
+    {{- with .Values.serviceapi.hostAliases }}
       hostAliases:
         {{- range . }}
         - ip: "{{ .ip }}"
-          hostnames: 
+          hostnames:
             {{- range .hostnames }}
             - "{{ . }}"
             {{- end }}
         {{- end }}
-      {{- end }}
-      {{- with .Values.imagePullSecrets }}
+    {{- end }}
+    {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+    {{- end }}
       initContainers:
-      - name: migrations-waiting-init
-        image: "{{ .Values.k8sWaitFor.image.repository }}:{{ .Values.k8sWaitFor.image.tag }}"
-        imagePullPolicy: IfNotPresent
-        args:
-          - "job-wr"
-          - {{ include "reportportal.fullname" . }}-migrations
-        resources:
-          requests:
-            cpu: 50m
-            memory: 100Mi
-          limits:
-            cpu: 50m
-            memory: 100Mi
-{{- if .Values.extraInitContainers }}
-{{ toYaml .Values.extraInitContainers | indent 8 }}
-{{- end }}
+        - name: migrations-waiting-init
+          image: "{{ .Values.k8sWaitFor.image.repository }}:{{ .Values.k8sWaitFor.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "job-wr"
+            - {{ include "reportportal.fullname" . }}-migrations
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+      {{- if .Values.extraInitContainers }}
+        {{ toYaml .Values.extraInitContainers | nindent 8 }}
+      {{- end }}
       containers:
-      - name: "{{ $.Values.serviceapi.name | default "api" }}"
-        image: "{{ .Values.serviceapi.image.repository }}:{{ .Values.serviceapi.image.tag }}"
-        imagePullPolicy: "{{ .Values.serviceapi.pullPolicy }}"
-        ports:
-        - containerPort: 8585
-          protocol: TCP
-        resources: {{- toYaml .Values.serviceapi.resources | nindent 10 }}
-        env:
-{{- if .Values.serviceapi.extraEnvs }}
-{{ toYaml .Values.serviceapi.extraEnvs | indent 8 }}
-{{- end }}
-        - name: SERVER_SERVLET_CONTEXT_PATH
-          value: "{{ $path }}/api"
-        - name: RP_JOBS_BASEURL
-          value: {{ ternary "https" "http" .Values.k8s.networking.ssl }}://{{ include "reportportal.fullname" . }}-jobs{{ printf ".%s.svc.cluster.local" .Release.Namespace }}:8686/jobs
-        - name: COM_TA_REPORTPORTAL_JOB_INTERRUPT_BROKEN_LAUNCHES_CRON
-          value: "{{ .Values.serviceapi.cronJobs.interruptBrockenLaunches }}"
-        - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_BATCH-SIZE
-          value: "{{ .Values.serviceapi.patternAnalysis.batchSize }}"
-        - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_PREFETCH-COUNT
-          value: "{{ .Values.serviceapi.patternAnalysis.prefetchCount }}"
-        - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_CONSUMERS-COUNT
-          value: "{{ .Values.serviceapi.patternAnalysis.consumersCount }}"
-        {{- if .Values.serviceapi.auditLogs.enable }}
-        - name: AUDIT_LOGGER
-          value: "{{ .Values.serviceapi.auditLogs.loglevel }}"
-        {{- end }}
-        - name: RP_ENVIRONMENT_VARIABLE_ALLOW_DELETE_ACCOUNT
-          value: "{{ .Values.serviceapi.allowDeleteAccount }}"
-        {{- if .Values.searchengine.doubleEntry.enable }}
-        - name: RP_ELASTICSEARCH_HOST
-          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.cluster.local" .Release.Namespace) }}:{{ .Values.searchengine.port }}"
-        {{- end }}
-        - name: LOGGING_LEVEL_ORG_HIBERNATE_SQL
-          value: "info"
-        - name: RP_REQUESTLOGGING
-          value: "false"
-        {{- if .Values.serviceapi.jvmArgs }}
-        - name: JAVA_OPTS
-          value: "{{ .Values.serviceapi.jvmArgs }}"
-        {{- end }}
-        # AMQP settings
-        - name: RP_AMQP_QUEUES
-          value: {{ .Values.serviceapi.queues.totalNumber | default "10" | quote }}
-        - name: RP_AMQP_QUEUESPERPOD
-          value: {{ .Values.serviceapi.queues.perPodNumber | default "10" | quote }}
-        - name: RP_AMQP_ANALYZER-VHOST
-          value: "{{ .Values.msgbroker.vhost }}"
-        - name: RP_AMQP_PASS
-        {{- if .Values.msgbroker.secretName }}
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.msgbroker.secretName }}"
-              key: "rabbitmq-password"
-        {{- else }}
-          value: "{{ .Values.msgbroker.password }}"
-        {{- end }}
-        - name: RP_AMQP_API_ADDRESS
-          value: {{ ternary "https" "http" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.apiuser }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.apiport }}/api
-        - name: RP_AMQP_ADDRESSES
-          value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}
-        # Database settings
-        - name: RP_DB_HOST
-          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
-        - name: RP_DB_PORT
-          value: "{{ .Values.database.port }}"
-        - name: RP_DB_NAME
-          value: "{{ .Values.database.dbName }}"
-        {{- if .Values.database.connections }}
-        - name: RP_DATASOURCE_MAXIMUMPOOLSIZE
-          value: "{{ .Values.database.connections }}"
-        {{- end }}
-        - name: RP_DB_USER
-          value: "{{ .Values.database.user }}"
-        - name: RP_DB_PASS
-        {{- if .Values.database.secretName }}
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.database.secretName }}"
-              key: "postgresql-password"
-        {{- else }}
-          value: "{{ .Values.database.password }}"
-        {{- end }}
-        - name: DATASTORE_TYPE
-          value: "{{ .Values.storage.type }}"
+        - name: "{{ $.Values.serviceapi.name | default "api" }}"
+          image: "{{ .Values.serviceapi.image.repository }}:{{ .Values.serviceapi.image.tag }}"
+          imagePullPolicy: "{{ .Values.serviceapi.pullPolicy }}"
+          ports:
+            - containerPort: 8585
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.serviceapi.resources | nindent 12 }}
+          env:
+          {{- if .Values.serviceapi.extraEnvs }}
+            {{ toYaml .Values.serviceapi.extraEnvs | nindent 12 }}
+          {{- end }}
+            - name: SERVER_SERVLET_CONTEXT_PATH
+              value: "{{ $path }}/api"
+            - name: RP_JOBS_BASEURL
+              value: {{ ternary "https" "http" .Values.k8s.networking.ssl }}://{{ include "reportportal.fullname" . }}-jobs{{ printf ".%s.svc.cluster.local" .Release.Namespace }}:8686/jobs
+            - name: COM_TA_REPORTPORTAL_JOB_INTERRUPT_BROKEN_LAUNCHES_CRON
+              value: "{{ .Values.serviceapi.cronJobs.interruptBrockenLaunches }}"
+            - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_BATCH-SIZE
+              value: "{{ .Values.serviceapi.patternAnalysis.batchSize }}"
+            - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_PREFETCH-COUNT
+              value: "{{ .Values.serviceapi.patternAnalysis.prefetchCount }}"
+            - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_CONSUMERS-COUNT
+              value: "{{ .Values.serviceapi.patternAnalysis.consumersCount }}"
+          {{- if .Values.serviceapi.auditLogs.enable }}
+            - name: AUDIT_LOGGER
+              value: "{{ .Values.serviceapi.auditLogs.loglevel }}"
+          {{- end }}
+            - name: RP_ENVIRONMENT_VARIABLE_ALLOW_DELETE_ACCOUNT
+              value: "{{ .Values.serviceapi.allowDeleteAccount }}"
+          {{- if .Values.searchengine.doubleEntry.enable }}
+            - name: RP_ELASTICSEARCH_HOST
+              value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.cluster.local" .Release.Namespace) }}:{{ .Values.searchengine.port }}"
+          {{- end }}
+            - name: LOGGING_LEVEL_ORG_HIBERNATE_SQL
+              value: "info"
+            - name: RP_REQUESTLOGGING
+              value: "false"
+          {{- if .Values.serviceapi.jvmArgs }}
+            - name: JAVA_OPTS
+              value: "{{ .Values.serviceapi.jvmArgs }}"
+          {{- end }}
+          # AMQP settings
+            - name: RP_AMQP_QUEUES
+              value: {{ .Values.serviceapi.queues.totalNumber | default "10" | quote }}
+            - name: RP_AMQP_QUEUESPERPOD
+              value: {{ .Values.serviceapi.queues.perPodNumber | default "10" | quote }}
+            - name: RP_AMQP_ANALYZER-VHOST
+              value: "{{ .Values.msgbroker.vhost }}"
+            - name: RP_AMQP_PASS
+          {{- if .Values.msgbroker.secretName }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.msgbroker.secretName }}"
+                  key: "rabbitmq-password"
+          {{- else }}
+              value: "{{ .Values.msgbroker.password }}"
+          {{- end }}
+            - name: RP_AMQP_API_ADDRESS
+              value: {{ ternary "https" "http" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.apiuser }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.apiport }}/api
+            - name: RP_AMQP_ADDRESSES
+              value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}
+          # Database settings
+            - name: RP_DB_HOST
+              value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+            - name: RP_DB_PORT
+              value: "{{ .Values.database.port }}"
+            - name: RP_DB_NAME
+              value: "{{ .Values.database.dbName }}"
+          {{- if .Values.database.connections }}
+            - name: RP_DATASOURCE_MAXIMUMPOOLSIZE
+              value: "{{ .Values.database.connections }}"
+          {{- end }}
+            - name: RP_DB_USER
+              value: "{{ .Values.database.user }}"
+            - name: RP_DB_PASS
+          {{- if .Values.database.secretName }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.database.secretName }}"
+                  key: "postgresql-password"
+          {{- else }}
+              value: "{{ .Values.database.password }}"
+          {{- end }}
+        # Storage settings
+            - name: DATASTORE_TYPE
+              value: "{{ .Values.storage.type }}"
+        # Minio/S3 settings
         {{- if or (eq .Values.storage.type "minio") (eq .Values.storage.type "s3") }}
-        {{- if eq .Values.storage.type "minio" }}
-        - name: DATASTORE_ENDPOINT
-          value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.storage.port }}"
+          {{- if eq .Values.storage.type "minio" }}
+            - name: DATASTORE_ENDPOINT
+              value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.storage.port }}"
+          {{- end }}
+          {{- if .Values.storage.region }}
+            - name: DATASTORE_REGION
+              value: "{{ .Values.storage.region }}"
+          {{- end }}
+          {{- if .Values.storage.secretName }}
+            - name: DATASTORE_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.storage.secretName }}"
+                  key: "{{ .Values.storage.accesskeyName }}"
+            - name: DATASTORE_SECRETKEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.storage.secretName }}"
+                  key: "{{ .Values.storage.secretkeyName }}"
+          {{- else }}
+            - name: DATASTORE_ACCESSKEY
+              value: "{{ .Values.storage.accesskey }}"
+            - name: DATASTORE_SECRETKEY
+              value: "{{ .Values.storage.secretkey }}"
+          {{- end }}
+          {{- if eq .Values.storage.bucket.type "single" }}
+            - name: RP_FEATURE_FLAGS
+              value: "singleBucket"
+          {{- end }}
+          {{- if eq .Values.storage.bucket.type "multi" }}
+            - name: DATASTORE_BUCKETPREFIX
+              value: "{{ .Values.storage.bucket.bucketMultiPrefix }}"
+            - name: DATASTORE_BUCKETPOSTFIX
+              value: "{{ .Values.storage.bucket.bucketMultiPostfix }}"
+            - name: RP_INTEGRATION_SALT_PATH
+              value: "{{ .Values.storage.bucket.bucketMultiSaltName }}"
+          {{- end }}
+            - name: DATASTORE_DEFAULTBUCKETNAME
+              value: "{{ .Values.storage.bucket.bucketDefaultName }}"
         {{- end }}
-        {{- if .Values.storage.region }}
-        - name: DATASTORE_REGION
-          value: "{{ .Values.storage.region }}"
-        {{- end }}
-        {{- if .Values.storage.secretName }}
-        - name: DATASTORE_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.storage.secretName }}"
-              key: "{{ .Values.storage.accesskeyName }}"
-        - name: DATASTORE_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.storage.secretName }}"
-              key: "{{ .Values.storage.secretkeyName }}"
-        {{- else }}
-        - name: DATASTORE_ACCESSKEY
-          value: "{{ .Values.storage.accesskey }}"
-        - name: DATASTORE_SECRETKEY
-          value: "{{ .Values.storage.secretkey }}"
-        {{- end }}
-        {{- if eq .Values.storage.bucket.type "single" }}
-        - name: RP_FEATURE_FLAGS
-          value: "singleBucket"
-        {{- end }}
-        {{- if eq .Values.storage.bucket.type "multi" }}
-        - name: DATASTORE_BUCKETPREFIX
-          value: "{{ .Values.storage.bucket.bucketMultiPrefix }}"
-        - name: DATASTORE_BUCKETPOSTFIX
-          value: "{{ .Values.storage.bucket.bucketMultiPostfix }}"
-        - name: RP_INTEGRATION_SALT_PATH
-          value: "{{ .Values.storage.bucket.bucketMultiSaltName }}"
-        {{- end }}
-        - name: DATASTORE_DEFAULTBUCKETNAME
-          value: "{{ .Values.storage.bucket.bucketDefaultName }}"
-        {{- end }}
-        - name: MANAGEMENT_HEALTH_ELASTICSEARCH_ENABLED
-          value: "false"
-        {{- if .Values.serviceapi.readinessProbe.enabled }}
-        readinessProbe:
-          httpGet:
-            path: "{{ $path }}/api/health"
-            port: 8585
-          initialDelaySeconds: {{ .Values.serviceapi.readinessProbe.initialDelaySeconds | default 30 }}
-          periodSeconds: {{ .Values.serviceapi.readinessProbe.periodSeconds | default 20 }}
-          timeoutSeconds: {{ .Values.serviceapi.readinessProbe.timeoutSeconds | default 3 }}
-          failureThreshold: {{ .Values.serviceapi.readinessProbe.failureThreshold | default 20 }}
-        {{- end }}
+            - name: MANAGEMENT_HEALTH_ELASTICSEARCH_ENABLED
+              value: "false"
+          {{- if .Values.serviceapi.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: "{{ $path }}/api/health"
+              port: 8585
+            initialDelaySeconds: {{ .Values.serviceapi.readinessProbe.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.serviceapi.readinessProbe.periodSeconds | default 20 }}
+            timeoutSeconds: {{ .Values.serviceapi.readinessProbe.timeoutSeconds | default 3 }}
+            failureThreshold: {{ .Values.serviceapi.readinessProbe.failureThreshold | default 20 }}
+          {{- end }}
         {{- if .Values.serviceapi.livenessProbe.enabled }}
-        livenessProbe:
-          httpGet:
-            path: "{{ $path }}/api/health"
-            port: 8585
-          initialDelaySeconds: {{ .Values.serviceapi.livenessProbe.initialDelaySeconds | default 30 }}
-          periodSeconds: {{ .Values.serviceapi.livenessProbe.periodSeconds | default 20 }}
-          timeoutSeconds: {{ .Values.serviceapi.livenessProbe.timeoutSeconds | default 5 }}
-          failureThreshold: {{ .Values.serviceapi.livenessProbe.failureThreshold | default 5 }}
+          livenessProbe:
+            httpGet:
+              path: "{{ $path }}/api/health"
+              port: 8585
+            initialDelaySeconds: {{ .Values.serviceapi.livenessProbe.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.serviceapi.livenessProbe.periodSeconds | default 20 }}
+            timeoutSeconds: {{ .Values.serviceapi.livenessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.serviceapi.livenessProbe.failureThreshold | default 5 }}
         {{- end }}
-        volumeMounts:
+          volumeMounts:
           {{- if .Values.serviceapi.secret.enabled }}
-          - name: {{ template "reportportal.name" . }}-serviceapi-secret
-            mountPath: {{ .Values.serviceapi.secret.mountPath }}
-            readOnly: {{ .Values.serviceapi.secret.readOnly }}
+            - name: {{ template "reportportal.name" . }}-serviceapi-secret
+              mountPath: {{ .Values.serviceapi.secret.mountPath }}
+              readOnly: {{ .Values.serviceapi.secret.readOnly }}
           {{- end }}
           {{- if .Values.serviceapi.auditLogs.enable }}
-          - name: audit-log-volume
-            mountPath: /var/log
+            - name: audit-log-volume
+              mountPath: /var/log
           {{- end }}
           {{- if eq .Values.storage.type "filesystem" }}
-          - name: shared-volume
-            mountPath: /data/storage
+            - name: shared-volume
+              mountPath: /data/storage
           {{- end }}
       {{- if .Values.serviceapi.auditLogs.enable }}
-      - name: auditlogstreamer
-        image: "{{ .Values.serviceapi.auditLogs.sidecar.image.repository }}:{{ .Values.serviceapi.auditLogs.sidecar.image.tag }}"
-        command:
-          - /bin/sh
-        args: 
-          - -c
-          - while true; do if [ -e "/var/log/reportportal/audit.log" ]; then tail -f /var/log/reportportal/audit.log; else sleep 60; fi; done
-        imagePullPolicy: IfNotPresent
-        resources: {{- toYaml .Values.serviceapi.auditLogs.sidecar.resources | nindent 10 }}
-        volumeMounts:
-          - name: audit-log-volume
-            mountPath: /var/log
+        - name: auditlogstreamer
+          image: "{{ .Values.serviceapi.auditLogs.sidecar.image.repository }}:{{ .Values.serviceapi.auditLogs.sidecar.image.tag }}"
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - while true; do if [ -e "/var/log/reportportal/audit.log" ]; then tail -f /var/log/reportportal/audit.log; else sleep 60; fi; done
+          imagePullPolicy: IfNotPresent
+          resources:
+            {{- toYaml .Values.serviceapi.auditLogs.sidecar.resources | nindent 12 }}
+          volumeMounts:
+            - name: audit-log-volume
+              mountPath: /var/log
       {{- end }}
-{{- if .Values.serviceapi.nodeSelector }}
+    {{- if .Values.serviceapi.nodeSelector }}
       nodeSelector:
         {{- range $key, $value := .Values.serviceapi.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-{{- end }}
+    {{- end }}
       securityContext:
-{{- toYaml .Values.serviceapi.securityContext | indent 8 }}
+        {{- toYaml .Values.serviceapi.securityContext | nindent 8 }}
       serviceAccountName: {{ .Values.serviceapi.serviceAccountName | default (include "reportportal.serviceAccountName" .) }}
-{{- with .Values.tolerations }}
+    {{- with .Values.tolerations }}
       tolerations:
-{{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       volumes:
-        {{- if .Values.serviceapi.secret.enabled }}
+      {{- if .Values.serviceapi.secret.enabled }}
         - name: {{ template "reportportal.name" . }}-serviceapi-secret
           secret:
             secretName: {{ template "reportportal.name" . }}-serviceapi-secret
-        {{- end }}
-        {{- if .Values.serviceapi.auditLogs.enable }}
+      {{- end }}
+      {{- if .Values.serviceapi.auditLogs.enable }}
         - name: audit-log-volume
-          emptyDir: {}
-        {{- end }}
-        {{- if eq .Values.storage.type "filesystem" }}
+          emptyDir: { }
+      {{- end }}
+      {{- if eq .Values.storage.type "filesystem" }}
         - name: shared-volume
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-shared-volume-claim
-        {{- end }}
+      {{- end }}

--- a/reportportal/templates/service-authorization/uat-deployment.yaml
+++ b/reportportal/templates/service-authorization/uat-deployment.yaml
@@ -119,12 +119,10 @@ spec:
         {{- else }}
           value: "{{ .Values.database.password }}"
         {{- end }}
-        {{- if eq .Values.storage.bucket.type "single" }}
-        - name: RP_FEATURE_FLAGS
-          value: "singleBucket"
-        {{- end }}
+        # Datastore settings
         - name: DATASTORE_TYPE
           value: "{{ .Values.storage.type }}"
+        {{- if or (eq .Values.storage.type "minio") (eq .Values.storage.type "s3") }}
         {{- if eq .Values.storage.type "minio" }}
         - name: DATASTORE_ENDPOINT
           value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.storage.port }}"
@@ -144,22 +142,27 @@ spec:
             secretKeyRef:
               name: "{{ .Values.storage.secretName }}"
               key: "{{ .Values.storage.secretkeyName }}"
-       {{- else }}
+        {{- else }}
         - name: DATASTORE_ACCESSKEY
           value: "{{ .Values.storage.accesskey }}"
         - name: DATASTORE_SECRETKEY
           value: "{{ .Values.storage.secretkey }}"
-       {{- end }}
-       {{- if eq .Values.storage.bucket.type "multi" }}
+        {{- end }}
+        {{- if eq .Values.storage.bucket.type "single" }}
+        - name: RP_FEATURE_FLAGS
+          value: "singleBucket"
+        {{- end }}
+        {{- if eq .Values.storage.bucket.type "multi" }}
         - name: DATASTORE_BUCKETPREFIX
           value: "{{ .Values.storage.bucket.bucketMultiPrefix }}"
         - name: DATASTORE_BUCKETPOSTFIX
           value: "{{ .Values.storage.bucket.bucketMultiPostfix }}"
         - name: RP_INTEGRATION_SALT_PATH
           value: "{{ .Values.storage.bucket.bucketMultiSaltName }}"
-       {{- end }}
+        {{- end }}
         - name: DATASTORE_DEFAULTBUCKETNAME
           value: "{{ .Values.storage.bucket.bucketDefaultName }}"
+        {{- end }}
         {{- if .Values.uat.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
@@ -182,9 +185,13 @@ spec:
         {{- end }}
         volumeMounts:
           {{- if .Values.uat.secret.enabled }}
-          - mountPath: {{ .Values.uat.secret.mountPath }}
-            name: {{ template "reportportal.name" . }}-uat-secret
+          - name: {{ template "reportportal.name" . }}-uat-secret
+            mountPath: {{ .Values.uat.secret.mountPath }}
             readOnly: {{ .Values.uat.secret.readOnly }}
+          {{- end }}
+          {{- if eq .Values.storage.type "filesystem" }}
+          - name: shared-volume
+            mountPath: /data/storage
           {{- end }}
 {{- if .Values.uat.nodeSelector }}
       nodeSelector:
@@ -204,4 +211,9 @@ spec:
         - name: {{ template "reportportal.name" . }}-uat-secret
           secret:
             secretName: {{ template "reportportal.name" . }}-uat-secret
+        {{- end }}
+        {{- if eq .Values.storage.type "filesystem" }}
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-shared-volume-claim
         {{- end }}

--- a/reportportal/templates/service-authorization/uat-deployment.yaml
+++ b/reportportal/templates/service-authorization/uat-deployment.yaml
@@ -22,198 +22,199 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
-      {{- with .Values.uat.hostAliases }}
+    {{- with .Values.uat.hostAliases }}
       hostAliases:
         {{- range . }}
         - ip: "{{ .ip }}"
-          hostnames: 
+          hostnames:
             {{- range .hostnames }}
             - "{{ . }}"
             {{- end }}
         {{- end }}
-      {{- end }}
-      {{- with .Values.imagePullSecrets }}
+    {{- end }}
+    {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+    {{- end }}
       initContainers:
-      - name: migrations-waiting-init
-        image: "{{ .Values.k8sWaitFor.image.repository }}:{{ .Values.k8sWaitFor.image.tag }}"
-        imagePullPolicy: IfNotPresent
-        args:
-          - "job-wr"
-          - {{ include "reportportal.fullname" . }}-migrations
-        resources:
-          requests:
-            cpu: 50m
-            memory: 100Mi
-          limits:
-            cpu: 50m
-            memory: 100Mi
-{{- if .Values.extraInitContainers }}
-{{ toYaml .Values.extraInitContainers | indent 8 }}
-{{- end }}
+        - name: migrations-waiting-init
+          image: "{{ .Values.k8sWaitFor.image.repository }}:{{ .Values.k8sWaitFor.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "job-wr"
+            - {{ include "reportportal.fullname" . }}-migrations
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+      {{- if .Values.extraInitContainers }}
+        {{ toYaml .Values.extraInitContainers | nindent 8 }}
+      {{- end }}
       containers:
-      - name: "{{ $.Values.uat.name | default "uat" }}"
-        image: "{{ .Values.uat.image.repository }}:{{ .Values.uat.image.tag }}"
-        imagePullPolicy: "{{ .Values.uat.pullPolicy }}"
-        ports:
-        - containerPort: 9999
-          protocol: TCP
-        resources:
-          requests:
-            cpu: {{ .Values.uat.resources.requests.cpu }}
-            memory: {{ .Values.uat.resources.requests.memory }}
-          limits:
-            cpu: {{ .Values.uat.resources.limits.cpu }}
-            memory: {{ .Values.uat.resources.limits.memory }}
-        env:
-{{- if .Values.uat.extraEnvs }}
-{{ toYaml .Values.uat.extraEnvs | indent 8 }}
-{{- end }}
-        - name: SERVER_SERVLET_CONTEXT_PATH
-          value: "{{ $path }}/uat"
-        - name: RP_AMQP_PASS
-        {{- if .Values.msgbroker.secretName }}
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.msgbroker.secretName }}"
-              key: "rabbitmq-password"
-        {{- else }}
-          value: "{{ .Values.msgbroker.password }}"
-        {{- end }}
-        - name: RP_AMQP_ADDRESSES
-          value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}'
-        {{- if .Values.uat.superadminInitPasswd.secretName }}
-        - name: RP_INITIAL_ADMIN_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.uat.superadminInitPasswd.secretName }}"
-              key: "{{ .Values.uat.superadminInitPasswd.passwordKeyName }}"
-        {{ else }}
-        - name: RP_INITIAL_ADMIN_PASSWORD
-          value: "{{ .Values.uat.superadminInitPasswd.password }}"
-        {{- end }}
-        - name: RP_SAML_SESSION-LIVE
-          value: "{{ .Values.uat.samlSessionLiveTime }}"
-        {{- if .Values.uat.jvmArgs }}
-        - name: JAVA_OPTS
-          value: "{{ .Values.uat.jvmArgs }}"
-        {{- end }}
-        - name: RP_SESSION_LIVE
-          value: "{{ .Values.uat.sessionLiveTime }}"
-        - name: RP_DB_HOST
-          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
-        - name: RP_DB_PORT
-          value: "{{ .Values.database.port }}"
-        - name: RP_DB_NAME
-          value: "{{ .Values.database.dbName }}"
-        - name: RP_DB_USER
-          value: "{{ .Values.database.user }}"
-        - name: RP_DB_PASS
-        {{- if .Values.database.secretName }}
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.database.secretName }}"
-              key: "postgresql-password"
-        {{- else }}
-          value: "{{ .Values.database.password }}"
-        {{- end }}
+        - name: "{{ $.Values.uat.name | default "uat" }}"
+          image: "{{ .Values.uat.image.repository }}:{{ .Values.uat.image.tag }}"
+          imagePullPolicy: "{{ .Values.uat.pullPolicy }}"
+          ports:
+            - containerPort: 9999
+              protocol: TCP
+          resources:
+            requests:
+              cpu: {{ .Values.uat.resources.requests.cpu }}
+              memory: {{ .Values.uat.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.uat.resources.limits.cpu }}
+              memory: {{ .Values.uat.resources.limits.memory }}
+          env:
+          {{- if .Values.uat.extraEnvs }}
+            {{ toYaml .Values.uat.extraEnvs | nindent 12 }}
+          {{- end }}
+            - name: SERVER_SERVLET_CONTEXT_PATH
+              value: "{{ $path }}/uat"
+            - name: RP_AMQP_PASS
+          {{- if .Values.msgbroker.secretName }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.msgbroker.secretName }}"
+                  key: "rabbitmq-password"
+          {{- else }}
+              value: "{{ .Values.msgbroker.password }}"
+          {{- end }}
+            - name: RP_AMQP_ADDRESSES
+              value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}'
+          {{- if .Values.uat.superadminInitPasswd.secretName }}
+            - name: RP_INITIAL_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.uat.superadminInitPasswd.secretName }}"
+                  key: "{{ .Values.uat.superadminInitPasswd.passwordKeyName }}"
+          {{ else }}
+            - name: RP_INITIAL_ADMIN_PASSWORD
+              value: "{{ .Values.uat.superadminInitPasswd.password }}"
+          {{- end }}
+            - name: RP_SAML_SESSION-LIVE
+              value: "{{ .Values.uat.samlSessionLiveTime }}"
+          {{- if .Values.uat.jvmArgs }}
+            - name: JAVA_OPTS
+              value: "{{ .Values.uat.jvmArgs }}"
+          {{- end }}
+            - name: RP_SESSION_LIVE
+              value: "{{ .Values.uat.sessionLiveTime }}"
+            - name: RP_DB_HOST
+              value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+            - name: RP_DB_PORT
+              value: "{{ .Values.database.port }}"
+            - name: RP_DB_NAME
+              value: "{{ .Values.database.dbName }}"
+            - name: RP_DB_USER
+              value: "{{ .Values.database.user }}"
+            - name: RP_DB_PASS
+          {{- if .Values.database.secretName }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.database.secretName }}"
+                  key: "postgresql-password"
+          {{- else }}
+              value: "{{ .Values.database.password }}"
+          {{- end }}
         # Datastore settings
-        - name: DATASTORE_TYPE
-          value: "{{ .Values.storage.type }}"
+            - name: DATASTORE_TYPE
+              value: "{{ .Values.storage.type }}"
+        # Minio/S3 settings
         {{- if or (eq .Values.storage.type "minio") (eq .Values.storage.type "s3") }}
-        {{- if eq .Values.storage.type "minio" }}
-        - name: DATASTORE_ENDPOINT
-          value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.storage.port }}"
-        {{- end }}
-        {{- if .Values.storage.region }}
-        - name: DATASTORE_REGION
-          value: "{{ .Values.storage.region }}"
-        {{- end }}
-        {{- if .Values.storage.secretName }}
-        - name: DATASTORE_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.storage.secretName }}"
-              key: "{{ .Values.storage.accesskeyName }}"
-        - name: DATASTORE_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.storage.secretName }}"
-              key: "{{ .Values.storage.secretkeyName }}"
-        {{- else }}
-        - name: DATASTORE_ACCESSKEY
-          value: "{{ .Values.storage.accesskey }}"
-        - name: DATASTORE_SECRETKEY
-          value: "{{ .Values.storage.secretkey }}"
-        {{- end }}
-        {{- if eq .Values.storage.bucket.type "single" }}
-        - name: RP_FEATURE_FLAGS
-          value: "singleBucket"
-        {{- end }}
-        {{- if eq .Values.storage.bucket.type "multi" }}
-        - name: DATASTORE_BUCKETPREFIX
-          value: "{{ .Values.storage.bucket.bucketMultiPrefix }}"
-        - name: DATASTORE_BUCKETPOSTFIX
-          value: "{{ .Values.storage.bucket.bucketMultiPostfix }}"
-        - name: RP_INTEGRATION_SALT_PATH
-          value: "{{ .Values.storage.bucket.bucketMultiSaltName }}"
-        {{- end }}
-        - name: DATASTORE_DEFAULTBUCKETNAME
-          value: "{{ .Values.storage.bucket.bucketDefaultName }}"
+          {{- if eq .Values.storage.type "minio" }}
+            - name: DATASTORE_ENDPOINT
+              value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.storage.port }}"
+          {{- end }}
+          {{- if .Values.storage.region }}
+            - name: DATASTORE_REGION
+              value: "{{ .Values.storage.region }}"
+          {{- end }}
+          {{- if .Values.storage.secretName }}
+            - name: DATASTORE_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.storage.secretName }}"
+                  key: "{{ .Values.storage.accesskeyName }}"
+            - name: DATASTORE_SECRETKEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.storage.secretName }}"
+                  key: "{{ .Values.storage.secretkeyName }}"
+          {{- else }}
+            - name: DATASTORE_ACCESSKEY
+              value: "{{ .Values.storage.accesskey }}"
+            - name: DATASTORE_SECRETKEY
+              value: "{{ .Values.storage.secretkey }}"
+          {{- end }}
+          {{- if eq .Values.storage.bucket.type "single" }}
+            - name: RP_FEATURE_FLAGS
+              value: "singleBucket"
+          {{- end }}
+          {{- if eq .Values.storage.bucket.type "multi" }}
+            - name: DATASTORE_BUCKETPREFIX
+              value: "{{ .Values.storage.bucket.bucketMultiPrefix }}"
+            - name: DATASTORE_BUCKETPOSTFIX
+              value: "{{ .Values.storage.bucket.bucketMultiPostfix }}"
+            - name: RP_INTEGRATION_SALT_PATH
+              value: "{{ .Values.storage.bucket.bucketMultiSaltName }}"
+          {{- end }}
+            - name: DATASTORE_DEFAULTBUCKETNAME
+              value: "{{ .Values.storage.bucket.bucketDefaultName }}"
         {{- end }}
         {{- if .Values.uat.readinessProbe.enabled }}
-        readinessProbe:
-          httpGet:
-            path: "{{ $path }}/uat/health"
-            port: 9999
-          initialDelaySeconds: {{ .Values.uat.readinessProbe.initialDelaySeconds | default 60 }}
-          periodSeconds: {{ .Values.uat.readinessProbe.periodSeconds | default 40 }}
-          timeoutSeconds: {{ .Values.uat.readinessProbe.timeoutSeconds | default 5 }}
-          failureThreshold: {{ .Values.uat.readinessProbe.failureThreshold | default 10 }}
-        {{- end }}
+          readinessProbe:
+            httpGet:
+              path: "{{ $path }}/uat/health"
+              port: 9999
+            initialDelaySeconds: {{ .Values.uat.readinessProbe.initialDelaySeconds | default 60 }}
+            periodSeconds: {{ .Values.uat.readinessProbe.periodSeconds | default 40 }}
+            timeoutSeconds: {{ .Values.uat.readinessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.uat.readinessProbe.failureThreshold | default 10 }}
+          {{- end }}
         {{- if .Values.uat.livenessProbe.enabled }}
-        livenessProbe:
-          httpGet:
-            path: "{{ $path }}/uat/health"
-            port: 9999
-          initialDelaySeconds: {{ .Values.uat.livenessProbe.initialDelaySeconds | default 60 }}
-          periodSeconds: {{ .Values.uat.livenessProbe.periodSeconds | default 40 }}
-          timeoutSeconds: {{ .Values.uat.livenessProbe.timeoutSeconds | default 5 }}
-          failureThreshold: {{ .Values.uat.livenessProbe.failureThreshold | default 10 }}
+          livenessProbe:
+            httpGet:
+              path: "{{ $path }}/uat/health"
+              port: 9999
+            initialDelaySeconds: {{ .Values.uat.livenessProbe.initialDelaySeconds | default 60 }}
+            periodSeconds: {{ .Values.uat.livenessProbe.periodSeconds | default 40 }}
+            timeoutSeconds: {{ .Values.uat.livenessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.uat.livenessProbe.failureThreshold | default 10 }}
         {{- end }}
-        volumeMounts:
+          volumeMounts:
           {{- if .Values.uat.secret.enabled }}
-          - name: {{ template "reportportal.name" . }}-uat-secret
-            mountPath: {{ .Values.uat.secret.mountPath }}
-            readOnly: {{ .Values.uat.secret.readOnly }}
+            - name: {{ template "reportportal.name" . }}-uat-secret
+              mountPath: {{ .Values.uat.secret.mountPath }}
+              readOnly: {{ .Values.uat.secret.readOnly }}
           {{- end }}
           {{- if eq .Values.storage.type "filesystem" }}
-          - name: shared-volume
-            mountPath: /data/storage
+            - name: shared-volume
+              mountPath: /data/storage
           {{- end }}
-{{- if .Values.uat.nodeSelector }}
+    {{- if .Values.uat.nodeSelector }}
       nodeSelector:
         {{- range $key, $value := .Values.uat.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-{{- end }}
+    {{- end }}
       securityContext:
-{{ toYaml .Values.uat.securityContext | indent 8}}
+        {{ toYaml .Values.uat.securityContext | nindent 8}}
       serviceAccountName: {{ .Values.uat.serviceAccountName | default (include "reportportal.serviceAccountName" .) }}
-{{- with .Values.tolerations }}
-      tolerations: 
-{{- toYaml . | nindent 8 }}
-{{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       volumes:
-        {{- if .Values.uat.secret.enabled }}
+      {{- if .Values.uat.secret.enabled }}
         - name: {{ template "reportportal.name" . }}-uat-secret
           secret:
             secretName: {{ template "reportportal.name" . }}-uat-secret
-        {{- end }}
-        {{- if eq .Values.storage.type "filesystem" }}
+      {{- end }}
+      {{- if eq .Values.storage.type "filesystem" }}
         - name: shared-volume
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-shared-volume-claim
-        {{- end }}
+      {{- end }}

--- a/reportportal/templates/service-jobs/jobs-deployment.yaml
+++ b/reportportal/templates/service-jobs/jobs-deployment.yaml
@@ -59,7 +59,6 @@ spec:
 {{- if .Values.servicejobs.extraEnvs }}
 {{ toYaml .Values.servicejobs.extraEnvs | indent 8 }}
 {{- end }}
-        #TODO: remove SERVER_SERVLET_CONTEXT_PATH after change base path in service-jobs
         - name: SERVER_SERVLET_CONTEXT_PATH
           value: "/jobs"
         {{- if .Values.searchengine.doubleEntry.enable }}
@@ -103,6 +102,7 @@ spec:
         - name: JAVA_OPTS
           value: "{{ .Values.servicejobs.jvmArgs }}"
         {{- end }}
+        # AMQP Settings
         - name: RP_AMQP_ANALYZER-VHOST
           value: "{{ .Values.msgbroker.vhost }}"
         - name: RP_AMQP_PASS
@@ -118,6 +118,7 @@ spec:
           value: {{ ternary "https" "http" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.apiuser }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.apiport }}/api
         - name: RP_AMQP_ADDRESSES
           value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}'
+        # Database settings
         - name: RP_DB_HOST
           value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
         - name: RP_DB_PORT
@@ -139,12 +140,10 @@ spec:
         {{- else }}
           value: "{{ .Values.database.password }}"
         {{- end }}
-        {{- if eq .Values.storage.bucket.type "single" }}
-        - name: RP_FEATURE_FLAGS
-          value: "singleBucket"
-        {{- end }}
+        # Storage settings
         - name: DATASTORE_TYPE
           value: "{{ .Values.storage.type }}"
+        {{- if or (eq .Values.storage.type "minio") (eq .Values.storage.type "s3") }}
         {{- if eq .Values.storage.type "minio" }}
         - name: DATASTORE_ENDPOINT
           value: "{{ ternary "https" "http" .Values.storage.ssl }}://{{ .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.storage.port }}"
@@ -164,22 +163,27 @@ spec:
             secretKeyRef:
               name: "{{ .Values.storage.secretName }}"
               key: "{{ .Values.storage.secretkeyName }}"
-       {{- else }}
+        {{- else }}
         - name: DATASTORE_ACCESSKEY
           value: "{{ .Values.storage.accesskey }}"
         - name: DATASTORE_SECRETKEY
           value: "{{ .Values.storage.secretkey }}"
-       {{- end }}
-       {{- if eq .Values.storage.bucket.type "multi" }}
+        {{- end }}
+        {{- if eq .Values.storage.bucket.type "single" }}
+        - name: RP_FEATURE_FLAGS
+          value: "singleBucket"
+        {{- end }}
+        {{- if eq .Values.storage.bucket.type "multi" }}
         - name: DATASTORE_BUCKETPREFIX
           value: "{{ .Values.storage.bucket.bucketMultiPrefix }}"
         - name: DATASTORE_BUCKETPOSTFIX
           value: "{{ .Values.storage.bucket.bucketMultiPostfix }}"
         - name: RP_INTEGRATION_SALT_PATH
           value: "{{ .Values.storage.bucket.bucketMultiSaltName }}"
-       {{- end }}
+        {{- end }}
         - name: DATASTORE_DEFAULTBUCKETNAME
           value: "{{ .Values.storage.bucket.bucketDefaultName }}"
+        {{- end }}
         - name: RP_PROCESSING_LOG_MAXBATCHSIZE
           value: "{{ .Values.servicejobs.logProcessing.maxBatchSize }}"
         - name: RP_PROCESSING_LOG_MAXBATCHTIMEOUT
@@ -206,6 +210,11 @@ spec:
           timeoutSeconds: {{ .Values.servicejobs.livenessProbe.timeoutSeconds | default 5 }}
           failureThreshold: {{ .Values.servicejobs.livenessProbe.failureThreshold | default 10 }}
         {{- end }}
+        volumeMounts:
+          {{- if eq .Values.storage.type "filesystem" }}
+          - name: shared-volume
+            mountPath: /data/storage
+          {{- end }}
 {{- if .Values.servicejobs.nodeSelector }}
       nodeSelector:
         {{- range $key, $value := .Values.servicejobs.nodeSelector }}
@@ -219,3 +228,9 @@ spec:
       tolerations:
 {{- toYaml . | nindent 8 }}
 {{- end }}
+      volumes:
+        {{- if eq .Values.storage.type "filesystem" }}
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-shared-volume-claim
+        {{- end }}

--- a/reportportal/templates/statefullset-auto-analyzer/analyzer-statefulset.yaml
+++ b/reportportal/templates/statefullset-auto-analyzer/analyzer-statefulset.yaml
@@ -126,6 +126,11 @@ spec:
         - name: UWSGI_WORKERS
           value: "{{ .Values.serviceanalyzer.uwsgiWorkers }}"
         {{- end }}
+        volumeMounts:
+          {{ if eq .Values.storage.type "filesystem" }}
+          - name: shared-volume
+            mountPath: /data/storage
+          {{- end }}
 {{- if .Values.serviceanalyzer.nodeSelector }}
       nodeSelector:
         {{- range $key, $value := .Values.serviceanalyzer.nodeSelector }}
@@ -139,3 +144,9 @@ spec:
       tolerations: 
 {{- toYaml . | nindent 8 }}
 {{- end }}
+      volumes:
+        {{- if eq .Values.storage.type "filesystem" }}
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-shared-volume-claim
+        {{- end }}

--- a/reportportal/templates/statefullset-auto-analyzer/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/statefullset-auto-analyzer/analyzertrain-statefulset.yaml
@@ -126,6 +126,11 @@ spec:
         - name: ES_PASSWORD
           value: "{{ .Values.searchengine.password }}" 
         {{- end }}
+        volumeMounts:
+          {{- if eq .Values.storage.type "filesystem" }}
+          - name: shared-volume
+            mountPath: /data/storage
+          {{- end }}
 {{- if .Values.serviceanalyzertrain.nodeSelector }}
       nodeSelector:
         {{- range $key, $value := .Values.serviceanalyzertrain.nodeSelector }}
@@ -139,3 +144,9 @@ spec:
       tolerations:
 {{- toYaml . | nindent 8 }}
 {{- end }}
+      volumes:
+        {{- if eq .Values.storage.type "filesystem" }}
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-shared-volume-claim
+        {{- end }}

--- a/reportportal/templates/volumes/pv.yaml
+++ b/reportportal/templates/volumes/pv.yaml
@@ -1,18 +1,53 @@
+# This snippet creates a PersistentVolume when ReportPortal uses
+# filesystem as a storage type instead of a bucket.
+# If you set a type of volume to 'gcp' or 'aws' in values.yaml
+# this snippet won't be used for creating a PersistentVolume.
+# GCP and AWS provides dynamic provisioning of volumes.
+# However, you can use a CSI type to get an access to pre-existing volumes.
+{{- if and (eq .Values.storage.type "filesystem") (ne .Values.storage.volume.volumeConfig.type "") }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ .Release.Name }}-shared-volume
   annotations: 
-    {{ .Values.storage.filesystem.volume.annotations | toYaml | nindent 4 }}
+    {{ .Values.storage.volume.annotations | toYaml | nindent 4 }}
 spec:
   capacity:
-    storage: {{ .Values.storage.filesystem.volume.capacity }}
+    storage: {{ .Values.storage.volume.capacity }}
   volumeMode: Filesystem
   accessModes:
-    {{- range .Values.storage.filesystem.volume.accessModes }}
-    - {{ . }}
-    {{- end }}
-  persistentVolumeReclaimPolicy: {{ .Values.storage.filesystem.volume.reclaimPolicy }}
-  storageClassName: {{ .Values.storage.filesystem.volume.storageClassName }}
+    - {{ .Values.storage.volume.accessModes | default "ReadWriteMany" }}
+  persistentVolumeReclaimPolicy: {{ .Values.storage.volume.reclaimPolicy | default "Retain" }}
+  storageClassName: {{ .Values.storage.volume.storageClassName }}
+
+# Connection type specific configuration
+{{- if eq .Values.storage.volume.volumeConfig.type "hostPath" }}
   hostPath:
-    path: "/data/{{ .Release.Name }}-shared-volume"
+    path: {{ .Values.storage.volume.volumeConfig.hostPath.path | default (printf "/data/%s-shared-volume" .Release.Name) }}
+{{- else if eq .Values.storage.volume.volumeConfig.type "local" }}
+  local:
+    path: {{ .Values.storage.volume.volumeConfig.local.path | default (printf "/data/%s-shared-volume" .Release.Name) }}
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                {{ .Values.storage.volume.volumeConfig.local.nodeSelectorNames | toYaml | nindent 16 }}
+{{- else if eq .Values.storage.volume.volumeConfig.type "csi" }}
+  csi:
+    driver: {{ .Values.storage.volume.volumeConfig.csi.driver }}
+    volumeHandle: {{ .Values.storage.volume.volumeConfig.csi.volumeHandle }}
+    {{- with .Values.storage.volume.volumeConfig.csi.fsType }}
+    fsType: {{ . }}
+    {{- end }}
+    {{- with .Values.storage.volume.volumeConfig.csi.readOnly }}
+    readOnly: {{ . }}
+    {{- end }}
+    volumeAttributes:
+      {{- range $key, $value := .Values.storage.volume.volumeConfig.csi.volumeAttributes }}
+      {{ $key }}: {{ $value }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/reportportal/templates/volumes/pv.yaml
+++ b/reportportal/templates/volumes/pv.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Release.Name }}-shared-volume
+  annotations: {}
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: "standard"
+  hostPath:
+    path: "/data/{{ .Release.Name }}-shared-volume"

--- a/reportportal/templates/volumes/pv.yaml
+++ b/reportportal/templates/volumes/pv.yaml
@@ -2,14 +2,17 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ .Release.Name }}-shared-volume
-  annotations: {}
+  annotations: 
+    {{ .Values.storage.filesystem.volume.annotations | toYaml | nindent 4 }}
 spec:
   capacity:
-    storage: 5Gi
+    storage: {{ .Values.storage.filesystem.volume.capacity }}
   volumeMode: Filesystem
   accessModes:
-    - ReadWriteMany
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: "standard"
+    {{- range .Values.storage.filesystem.volume.accessModes }}
+    - {{ . }}
+    {{- end }}
+  persistentVolumeReclaimPolicy: {{ .Values.storage.filesystem.volume.reclaimPolicy }}
+  storageClassName: {{ .Values.storage.filesystem.volume.storageClassName }}
   hostPath:
     path: "/data/{{ .Release.Name }}-shared-volume"

--- a/reportportal/templates/volumes/pvc.yaml
+++ b/reportportal/templates/volumes/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-shared-volume-claim
+  annotations: {}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: "standard"

--- a/reportportal/templates/volumes/pvc.yaml
+++ b/reportportal/templates/volumes/pvc.yaml
@@ -2,11 +2,14 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-shared-volume-claim
-  annotations: {}
+  annotations: 
+    {{ .Values.storage.filesystem.volume.annotations | toYaml | nindent 4 }}
 spec:
   accessModes:
-    - ReadWriteMany
+    {{- range .Values.storage.filesystem.volume.accessModes }}
+    - {{ . }}
+    {{- end }}
   resources:
     requests:
-      storage: 5Gi
-  storageClassName: "standard"
+      storage: {{ .Values.storage.filesystem.volume.capacity }}
+  storageClassName: {{ .Values.storage.filesystem.volume.storageClassName }}

--- a/reportportal/templates/volumes/pvc.yaml
+++ b/reportportal/templates/volumes/pvc.yaml
@@ -1,15 +1,15 @@
+{{- if eq .Values.storage.type "filesystem" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-shared-volume-claim
   annotations: 
-    {{ .Values.storage.filesystem.volume.annotations | toYaml | nindent 4 }}
+    {{ .Values.storage.volume.annotations | toYaml | nindent 4 }}
 spec:
-  accessModes:
-    {{- range .Values.storage.filesystem.volume.accessModes }}
-    - {{ . }}
-    {{- end }}
+  accessModes: 
+    - {{ .Values.storage.volume.accessMode | default "ReadWriteMany" }}
   resources:
     requests:
-      storage: {{ .Values.storage.filesystem.volume.capacity }}
-  storageClassName: {{ .Values.storage.filesystem.volume.storageClassName }}
+      storage: {{ .Values.storage.volume.capacity }}
+  storageClassName: {{ .Values.storage.volume.storageClassName }}
+{{- end }}

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -537,7 +537,7 @@ searchengine:
   password:
 
 storage:
-  ## @param storage.type Possible storage types: minio, s3
+  ## @param storage.type Possible storage types: minio, s3, filesystem
   type: minio
   secretName: ""
   ## @param storage.accesskeyName and @param storage.secretkeyName pass to the env[].valueFrom.secretKeyRef.key

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -578,11 +578,7 @@ storage:
     annotations: {}
     ## @param storage.volume.volumeConfig contains objects for creating
     ## a persistent volume configuration.
-    ## @param storage.volume.type defines the PersistentVolume type.
-    ## If you don't want to use a dynamic provisioner, set the type for
-    ## cases when you have a pre-existing volume.
     ## Possible values: hostPath, local, csi.
-    ## We recommend using the hostPath provider for development purposes only.
     volumeConfig:
       type: ""
       hostPath: {}

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -567,6 +567,24 @@ storage:
     bucketMultiPostfix: ""
     ## @param storage.bucket.bucketMultiSaltName storing auth keystore
     bucketMultiSaltName: "keystore"
+  ## @param storage.filesystem defines the storage properties for the filesystem storage type
+  filesystem:
+    ## @param storage.filesystem.volume defines the common persistent volume parameters.
+    ## Some parameters are not applicable if @param storage.filesystem.gcpFilestore
+    ## or @param storage.filesystem.awsEfs is enabled.
+    volume:
+      ## @param storage.filesystem.volume.capacity defines the size of the storage.
+      capacity: 5Gi
+      ## @param storage.filesystem.annotations defines the common annotations. 
+      annotations: {}
+      storageClassName: "standard"
+      accessModes:
+        - ReadWriteMany
+      reclaimPolicy: Retain
+    gcpFilestore:
+      enabled: false
+    awsEfs:
+      enabled: false
 
 ## @section Ingress configuration
 

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -567,24 +567,45 @@ storage:
     bucketMultiPostfix: ""
     ## @param storage.bucket.bucketMultiSaltName storing auth keystore
     bucketMultiSaltName: "keystore"
-  ## @param storage.filesystem defines the storage properties for the filesystem storage type
-  filesystem:
-    ## @param storage.filesystem.volume defines the common persistent volume parameters.
-    ## Some parameters are not applicable if @param storage.filesystem.gcpFilestore
-    ## or @param storage.filesystem.awsEfs is enabled.
-    volume:
-      ## @param storage.filesystem.volume.capacity defines the size of the storage.
-      capacity: 5Gi
-      ## @param storage.filesystem.annotations defines the common annotations. 
-      annotations: {}
-      storageClassName: "standard"
-      accessModes:
-        - ReadWriteMany
-      reclaimPolicy: Retain
-    gcpFilestore:
-      enabled: false
-    awsEfs:
-      enabled: false
+  ## @param storage.volume defines the persistent volume claim properties
+  ## for the filesystem storage type.
+  volume:
+    ## @param storage.volume.capacity defines the size of the storage.
+    capacity: 5Gi
+    ## @param storage.volume.storageClassName defines the storage class name.
+    storageClassName: "standard"
+    ## @param storage.volume.annotations defines the common annotations.
+    annotations: {}
+    ## @param storage.volume.volumeConfig contains objects for creating
+    ## a persistent volume configuration.
+    ## @param storage.volume.type defines the PersistentVolume type.
+    ## If you don't want to use a dynamic provisioner, set the type for
+    ## cases when you have a pre-existing volume.
+    ## Possible values: hostPath, local, csi.
+    ## We recommend using the hostPath provider for development purposes only.
+    volumeConfig:
+      type: ""
+      hostPath: {}
+      local:
+        nodeSelectorNames: []
+      ## @param storage.volume.volumeConfig.csi defines
+      ## the Container Storage Interface (CSI) properties.
+      csi:
+        ## @param storage.volume.volumeConfig.csi.driver defines
+        ## the CSI driver name.
+        driver: ""
+        ## @param storage.volume.volumeConfig.csi.volumeHandle defines
+        ## the volume handle.
+        volumeHandle: ""
+        ## @param storage.volume.volumeConfig.csi.fsType defines
+        ## the filesystem type. Provide ext4, xfs, etc.
+        fsType: ""
+        ## @param storage.volume.volumeConfig.csi.readOnly defines if
+        ## the volume is read-only. Provide true or false.
+        readOnly: ""
+        ## @param storage.volume.volumeConfig.csi.volumeAttributes defines
+        ## additional volume attributes.
+        volumeAttributes: {}
 
 ## @section Ingress configuration
 

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -576,10 +576,11 @@ storage:
     storageClassName: "standard"
     ## @param storage.volume.annotations defines the common annotations.
     annotations: {}
-    ## @param storage.volume.volumeConfig contains objects for creating
-    ## a persistent volume configuration.
-    ## Possible values: hostPath, local, csi.
+    ## @param storage.volume.volumeConfig contains configuration for creating
+    ## a persistent volume.
     volumeConfig:
+      ## @param storage.volume.volumeConfig.type defines the Persistent Volume type.
+      ## Possible values: hostPath, local, csi. If empty, PV is not created.
       type: ""
       hostPath: {}
       local:


### PR DESCRIPTION
When we set `filesystem` for the `storage.type` value, Helm creates a persistent volume claim with an access mode `ReadWriteMany` .
Moreover, we can define a persistent volume resource with `local,` `hostPath`, and `csi` types for adding pre-existing volumes. 