### PR TITLE
Release 24.1.2 Helm chart update (#391)

### DIFF
--- a/reportportal/Chart.yaml
+++ b/reportportal/Chart.yaml
@@ -29,6 +29,6 @@ dependencies:
     condition: opensearch.install
 
   - name: minio
-    version: 14.5.0
+    version: 14.6.13
     repository: https://charts.bitnami.com/bitnami
     condition: minio.install

--- a/reportportal/templates/service-api/api-service.yaml
+++ b/reportportal/templates/service-api/api-service.yaml
@@ -5,8 +5,8 @@ metadata:
   labels: {{ include "labels" . | indent 4 }}
   annotations:
     service: {{ $.Values.serviceapi.name | default "api" }}
-    infoEndpoint: "/api/info"
-    healthEndpoint: "/api/health"
+    infoEndpoint: "{{- $path := .Values.ingress.path -}}/api/info"
+    healthEndpoint: "{{- $path := .Values.ingress.path -}}/api/health"
     {{- with .Values.serviceapi.service.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/reportportal/templates/service-authorization/uat-service.yaml
+++ b/reportportal/templates/service-authorization/uat-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels: {{ include "labels" . | indent 4 }}
   annotations:
     service: {{ $.Values.uat.name | default "uat" }}
-    infoEndpoint: "/uat/info"
+    infoEndpoint: "{{- $path := .Values.ingress.path -}}/uat/info"
     healthEndpoint: "/uat/health"
     {{- with .Values.uat.service.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/reportportal/templates/service-index/index-service.yaml
+++ b/reportportal/templates/service-index/index-service.yaml
@@ -5,8 +5,8 @@ metadata:
   labels: {{ include "labels" . | indent 4 }}
   annotations:
     service: {{ $.Values.serviceindex.name | default "index" }}
-    infoEndpoint: "/info"
-    healthEndpoint: "/health"
+    infoEndpoint: "{{- $path := .Values.ingress.path -}}/info"
+    healthEndpoint: "{{- $path := .Values.ingress.path -}}/health"
     {{- with .Values.serviceindex.service.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/reportportal/templates/service-jobs/jobs-services.yaml
+++ b/reportportal/templates/service-jobs/jobs-services.yaml
@@ -5,8 +5,8 @@ metadata:
   labels: {{ include "labels" . | indent 4 }}
   annotations:
     service: {{ $.Values.servicejobs.name | default "jobs" }}
-    infoEndpoint: "/jobs/info"
-    healthEndpoint: "/jobs/health"
+    infoEndpoint: "{{- $path := .Values.ingress.path -}}/jobs/info"
+    healthEndpoint: "{{- $path := .Values.ingress.path -}}/jobs/health"
     {{- with .Values.servicejobs.service.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/reportportal/templates/service-ui/ui-service.yaml
+++ b/reportportal/templates/service-ui/ui-service.yaml
@@ -5,8 +5,8 @@ metadata:
   labels: {{ include "labels" . | indent 4 }}
   annotations:
     service: {{ $.Values.serviceui.name | default "ui" }}
-    infoEndpoint: "/ui/info"
-    healthEndpoint: "/ui/health"
+    infoEndpoint: "{{- $path := .Values.ingress.path -}}/ui/info"
+    healthEndpoint: "{{- $path := .Values.ingress.path -}}/ui/health"
     {{- with .Values.serviceui.service.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -718,6 +718,9 @@ rabbitmq:
   containerPorts:
     amqp: *msgbrokerPort
     manager: *msgbrokerApiPort
+  ## @param rabbitmq.extraPlugins define additional RabbitMQ plugins to be enabled.
+  ## Consistent Hash Exchange is required for the ReportPortal.
+  extraPlugins: "rabbitmq_auth_backend_ldap rabbitmq_consistent_hash_exchange"
 
 ## @param opensearch External OpenSearch Helm Chart as dependency
 opensearch:
@@ -743,10 +746,13 @@ minio:
   image:
     repository: bitnami/minio
     registry: docker.io
-    tag: 2024.5.10-debian-12-r2
+    tag: 2024.6.26-debian-12-r0
   auth:
     rootUser: *storageAccessKey
     rootPassword: *storageSecretKey
+  persistence:
+    annotations:
+      "helm.sh/resource-policy": "keep"
 
 k8sWaitFor:
   image:


### PR DESCRIPTION
* Fix uat readiness values

* Ingress path configuration

* Ingress path remove

* Merge develop

* added hostAliases for API

* hostAliases added for uat service

* Add path variable

* Add path variable

* Add path variables

* Fix some comments

* Action version update

* Update uat-deployment.yaml (#377)

* Update minikube-install.md

* Update minikube-install.md

* Add persistent volume storge support (#380)

* Add templates for PV and PVC

* Add values for config PV and PVC

* Update GKE installation guide

* Update Minikube installation guide

* Update all chart dependencies to the latest versions (#381)

* Bump charts and image versions

* Add gcpManaged cert checking

* Add support for setting hosts as string or array

* Add ARM arch support for init containers (#382)

* Change k8sWaitFor repo

* Split uat-secret according to the Helm linter error

* Split LOCATION env in GKE Installation guide

* Helm add readiness test (#383)

* Update reportportal/migrations image tag to 5.11.1

* Add Helm readiness test

* Update README.md (#386)

* Update gke-install.md

* Update gke-install.md

* chore: add extra RabbitMQ plugins for consistent hash exchange

* chore: enable consistent hash exchange RabbitMQ plugin

* chore: Update minio chart and image versions

* Update services endpoints in YAML templates (#390)

---------