### PR TITLE
feat: allow parametrization of db password key

### DIFF
--- a/reportportal/templates/service-api/api-deployment.yaml
+++ b/reportportal/templates/service-api/api-deployment.yaml
@@ -133,7 +133,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: "{{ .Values.database.secretName }}"
-                  key: "postgresql-password"
+                  key: "{{ .Values.database.passwordKeyName }}"
           {{- else }}
               value: "{{ .Values.database.password }}"
           {{- end }}

--- a/reportportal/templates/service-authorization/uat-deployment.yaml
+++ b/reportportal/templates/service-authorization/uat-deployment.yaml
@@ -115,7 +115,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: "{{ .Values.database.secretName }}"
-                  key: "postgresql-password"
+                  key: "{{ .Values.database.passwordKeyName }}"
           {{- else }}
               value: "{{ .Values.database.password }}"
           {{- end }}

--- a/reportportal/templates/service-jobs/jobs-deployment.yaml
+++ b/reportportal/templates/service-jobs/jobs-deployment.yaml
@@ -136,7 +136,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.database.secretName }}"
-              key: "postgresql-password"
+              key: "{{ .Values.database.passwordKeyName }}"
         {{- else }}
           value: "{{ .Values.database.password }}"
         {{- end }}

--- a/reportportal/templates/service-migrations/migrations-job.yaml
+++ b/reportportal/templates/service-migrations/migrations-job.yaml
@@ -38,7 +38,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.database.secretName }}"
-              key: "postgresql-password"
+              key: "{{ .Values.database.passwordKeyName }}"
         {{ else }}
           value: "{{ .Values.database.password }}"
         {{ end }}

--- a/reportportal/templates/statefullset-auto-analyzer/metrics-gatherer-deployment.yaml
+++ b/reportportal/templates/statefullset-auto-analyzer/metrics-gatherer-deployment.yaml
@@ -106,7 +106,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.database.secretName }}"
-              key: "postgresql-password"
+              key: "{{ .Values.database.passwordKeyName }}"
         {{- else }}
           value: "{{ .Values.database.password }}"
         {{- end }}

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -494,6 +494,7 @@ migrations:
 
 database:
   secretName: ""
+  passwordKeyName: "postgresql-password"
   ## @param database.endpoint by default {{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local
   endpoint:
   port: &dbport 5432


### PR DESCRIPTION
Our team uses Postgres Zalando operator inside K8s cluster. It creates a Secret with a database password under the `password` key.
Parametrization of this value would allow us to use Postgres Zalando operator by changing the hardcoded `postgresql-password` to a `password` key.

The same as concept as https://github.com/reportportal/kubernetes/blob/dc395f749866056a52a6c874cdf0878c5996441d/reportportal/values.yaml#L226