### PR TITLE
Fix: UAT pod crash at initialization if password is not set

### DIFF
--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -249,7 +249,7 @@ uat:
   superadminInitPasswd:
     secretName: ""
     passwordKeyName: "superadmin-password"
-    password: ""
+    password: "erebus"
   
   ## @param serviceapi.javaArgs define the configuration for the JVM.
   ## For custom java keystore add parameter: -Djavax.net.ssl.trustStore=/etc/secret-volume/custom-pki.jks


### PR DESCRIPTION
Password took from step 2 from https://reportportal.io/installation

Helm Chart Version: 24.1.2