### PR TITLE
Add affinity support

### DIFF
--- a/reportportal/templates/service-api/api-deployment.yaml
+++ b/reportportal/templates/service-api/api-deployment.yaml
@@ -21,6 +21,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+    {{- with .Values.serviceapi.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.serviceapi.hostAliases }}
       hostAliases:
         {{- range . }}

--- a/reportportal/templates/service-authorization/uat-deployment.yaml
+++ b/reportportal/templates/service-authorization/uat-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+    {{- with .Values.uat.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.uat.hostAliases }}
       hostAliases:
         {{- range . }}

--- a/reportportal/templates/service-index/index-deployment.yaml
+++ b/reportportal/templates/service-index/index-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- with .Values.serviceindex.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/reportportal/templates/service-jobs/jobs-deployment.yaml
+++ b/reportportal/templates/service-jobs/jobs-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- with .Values.servicejobs.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/reportportal/templates/service-migrations/migrations-job.yaml
+++ b/reportportal/templates/service-migrations/migrations-job.yaml
@@ -17,6 +17,10 @@ spec:
         {{- end }}
     spec:
       restartPolicy: OnFailure
+      {{- with .Values.migrations.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/reportportal/templates/service-ui/ui-deployment.yaml
+++ b/reportportal/templates/service-ui/ui-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- with .Values.serviceui.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/reportportal/templates/statefullset-auto-analyzer/analyzer-statefulset.yaml
+++ b/reportportal/templates/statefullset-auto-analyzer/analyzer-statefulset.yaml
@@ -21,6 +21,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- with .Values.serviceanalyzer.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/reportportal/templates/statefullset-auto-analyzer/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/statefullset-auto-analyzer/analyzertrain-statefulset.yaml
@@ -21,6 +21,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- with .Values.serviceanalyzertrain.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/reportportal/templates/statefullset-auto-analyzer/metrics-gatherer-deployment.yaml
+++ b/reportportal/templates/statefullset-auto-analyzer/metrics-gatherer-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- with .Values.metricsgatherer.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -30,6 +30,7 @@ serviceindex:
     limits:
       cpu: 200m
       memory: 256Mi
+  affinity: {}
   podLabels: {}
   podAnnotations: {}
   securityContext: {}
@@ -64,6 +65,7 @@ serviceui:
     limits:
       cpu: 200m
       memory: 128Mi
+  affinity: {}
   podLabels: {}
   podAnnotations: {}
   securityContext: {}
@@ -185,6 +187,7 @@ serviceapi:
     #     secretKeyRef:
     #       name: "additional-credentials"
     #       key: username
+  affinity: {}
   podLabels: {}
   podAnnotations: {}
   securityContext: {}
@@ -284,6 +287,7 @@ uat:
     #     secretKeyRef:
     #       name: "additional-credentials"
     #       key: username
+  affinity: {}
   podLabels: {}
   podAnnotations: {}
   securityContext: {}
@@ -389,6 +393,7 @@ servicejobs:
     #     secretKeyRef:
     #       name: "additional-credentials"
     #       key: username
+  affinity: {}
   podLabels: {}
   podAnnotations: {}
   securityContext: {}
@@ -424,6 +429,7 @@ serviceanalyzer:
     limits:
       cpu: 500m
       memory: 1Gi
+  affinity: {}
   podLabels: {}
   podAnnotations: {}
   securityContext: {}
@@ -466,6 +472,7 @@ serviceanalyzertrain:
     limits:
       cpu: 200m
       memory: 512Mi
+  affinity: {}
   podLabels: {}
   podAnnotations: {}
   securityContext: {}
@@ -515,6 +522,7 @@ metricsgatherer:
     limits:
       cpu: 16m
       memory: 256Mi
+  affinity: {}
   podLabels: {}
   podAnnotations: {}
   securityContext: {}
@@ -555,6 +563,7 @@ migrations:
       cpu: 100m
       memory: 128Mi
   pullPolicy: Always
+  affinity: {}
   podLabels: {}
   podAnnotations: {}
   securityContext: {}


### PR DESCRIPTION
Affinity rules can be set to control where pods will be scheduled