### PR TITLE
allow setting annotations for pre-upgrade-cleanup job

### DIFF
--- a/reportportal/templates/hooks/upgrade/pre-upgrade-cleanup.yaml
+++ b/reportportal/templates/hooks/upgrade/pre-upgrade-cleanup.yaml
@@ -16,6 +16,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         component: {{ include "reportportal.fullname" . }}-pre-upgrade-cleanup
+      annotations:
+        {{- range $key, $value := .Values.migrations.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "reportportal.serviceAccountName" . }}
       restartPolicy: OnFailure


### PR DESCRIPTION
This allows users (like us) to set an annotation to not inject Istio sidecar into the ephemereal Job pod, which usually causes problems by leaving a zombie/hanging container which never exits.