### PR TITLE
fix(extraInitContainers) in the statefullset-auto-analyzer deployment templates

### DIFF
--- a/reportportal/templates/service-auto-analyzer/analyzer-statefulset.yaml
+++ b/reportportal/templates/service-auto-analyzer/analyzer-statefulset.yaml
@@ -43,8 +43,8 @@ spec:
             limits:
               cpu: 50m
               memory: 100Mi
-      {{- if .Values.serviceanalyzer.extraInitContainers }}
-        {{ toYaml .Values.serviceanalyzer.extraInitContainers | nindent 8 }}
+      {{- if .Values.serviceanalyzertrain.extraInitContainers }}
+        {{ toYaml .Values.serviceanalyzertrain.extraInitContainers | nindent 8 }}
       {{- end }}
       containers:
       - name: "{{ $.Values.serviceanalyzer.name | default "analyzer" }}"
@@ -184,6 +184,6 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-shared-volume-claim
       {{- end }}
-      {{- if .Values.serviceanalyzer.extraVolumes }}
-        {{ toYaml .Values.serviceanalyzer.extraVolumes | nindent 8 }}
+      {{- if .Values.serviceanalyzertrain.extraVolumes }}
+        {{ toYaml .Values.serviceanalyzertrain.extraVolumes | nindent 8 }}
       {{- end }}

--- a/reportportal/templates/service-auto-analyzer/analyzer-statefulset.yaml
+++ b/reportportal/templates/service-auto-analyzer/analyzer-statefulset.yaml
@@ -30,19 +30,19 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-      - name: migrations-waiting-init
-        image: "{{ include "reportportal.image" (dict "Values" .Values "service" "k8sWaitFor") }}"
-        imagePullPolicy: IfNotPresent
-        args:
-          - "pod-wr"
-          - "-lcomponent={{ include "reportportal.fullname" . }}-api"
-        resources:
-          requests:
-            cpu: 50m
-            memory: 100Mi
-          limits:
-            cpu: 50m
-            memory: 100Mi
+        - name: migrations-waiting-init
+          image: "{{ include "reportportal.image" (dict "Values" .Values "service" "k8sWaitFor") }}"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "pod-wr"
+            - "-lcomponent={{ include "reportportal.fullname" . }}-api"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
       {{- if .Values.serviceanalyzer.extraInitContainers }}
         {{ toYaml .Values.serviceanalyzer.extraInitContainers | nindent 8 }}
       {{- end }}

--- a/reportportal/templates/service-auto-analyzer/analyzer-statefulset.yaml
+++ b/reportportal/templates/service-auto-analyzer/analyzer-statefulset.yaml
@@ -43,8 +43,8 @@ spec:
             limits:
               cpu: 50m
               memory: 100Mi
-      {{- if .Values.serviceanalyzertrain.extraInitContainers }}
-        {{ toYaml .Values.serviceanalyzertrain.extraInitContainers | nindent 8 }}
+      {{- if .Values.serviceanalyzer.extraInitContainers }}
+        {{ toYaml .Values.serviceanalyzer.extraInitContainers | nindent 8 }}
       {{- end }}
       containers:
       - name: "{{ $.Values.serviceanalyzer.name | default "analyzer" }}"
@@ -184,6 +184,6 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-shared-volume-claim
       {{- end }}
-      {{- if .Values.serviceanalyzertrain.extraVolumes }}
-        {{ toYaml .Values.serviceanalyzertrain.extraVolumes | nindent 8 }}
+      {{- if .Values.serviceanalyzer.extraVolumes }}
+        {{ toYaml .Values.serviceanalyzer.extraVolumes | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
### Fix: Indentation Error in Analyzer StatefulSets to Support `extraInitContainers`

We’ve started deploying the ReportPortal Helm chart to our GKE cluster and needed to configure `extraInitContainers` for the `serviceanalyzer` and `serviceanalyzertrain` components. These init containers enable mounting a GCS bucket using `gcsfuse`, allowing ReportPortal to use Google Cloud Storage as a backing store.

However, we ran into a YAML parsing error due to incorrect indentation in the following templates:

* `analyzertrain-statefulset.yaml`
* `analyzer-statefulset.yaml`

This prevented us from defining `extraInitContainers` via `values.yaml`.

```bash
Error: YAML parse error on ...: yaml: line 36: did not find expected key
```

This PR corrects the indentation so that users can cleanly define `extraInitContainers` like the following example:

```yaml
reportportal:
  serviceanalyzer:
    extraInitContainers:
      - name: gcsfuse
        image: gcfuse:latest
        ...
  serviceanalyzertrain:
    extraInitContainers:
      - name: gcsfuse
        image: gcfuse:latest
        ...
```

With this fix, `helm template` works as expected and supports GCS integration through properly defined init containers.