### PR TITLE
[BUG] - Scoped labels and annotations logic for deployment s

### DIFF
--- a/reportportal/templates/service-api/api-deployment.yaml
+++ b/reportportal/templates/service-api/api-deployment.yaml
@@ -12,13 +12,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- range $key, $value := .Values.serviceapi.podLabels }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.serviceapi.podLabels }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
-        component: {{ include "reportportal.fullname" . }}-api
+        component: { { include "reportportal.fullname" . } }-api
       annotations:
-        {{- range $key, $value := .Values.serviceapi.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.serviceapi.podAnnotations }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
     spec:
     {{- with .Values.serviceapi.affinity }}

--- a/reportportal/templates/service-authorization/uat-deployment.yaml
+++ b/reportportal/templates/service-authorization/uat-deployment.yaml
@@ -13,13 +13,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- range $key, $value := .Values.uat.podLabels }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.uat.podLabels }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
-        component: {{ include "reportportal.fullname" . }}-uat
+        component: { { include "reportportal.fullname" . } }-uat
       annotations:
-        {{- range $key, $value := .Values.uat.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.uat.podAnnotations }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
     spec:
     {{- with .Values.uat.affinity }}

--- a/reportportal/templates/service-index/index-deployment.yaml
+++ b/reportportal/templates/service-index/index-deployment.yaml
@@ -13,13 +13,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- range $key, $value := .Values.serviceindex.podLabels }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.serviceindex.podLabels }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
-        component: {{ include "reportportal.fullname" . }}-index
+        component: { { include "reportportal.fullname" . } }-index
       annotations:
-        {{- range $key, $value := .Values.serviceindex.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.serviceindex.podAnnotations }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
     spec:
       {{- with .Values.serviceindex.affinity }}

--- a/reportportal/templates/service-jobs/jobs-deployment.yaml
+++ b/reportportal/templates/service-jobs/jobs-deployment.yaml
@@ -11,13 +11,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- range $key, $value := .Values.servicejobs.podLabels }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.servicejobs.podLabels }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
-        component: {{ include "reportportal.fullname" . }}-jobs
+        component: { { include "reportportal.fullname" . } }-jobs
       annotations:
-        {{- range $key, $value := .Values.servicejobs.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.servicejobs.podAnnotations }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
     spec:
       {{- with .Values.servicejobs.affinity }}

--- a/reportportal/templates/service-migrations/migrations-job.yaml
+++ b/reportportal/templates/service-migrations/migrations-job.yaml
@@ -7,13 +7,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- range $key, $value := .Values.migrations.podLabels }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.migrations.podLabels }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
         component: {{ include "reportportal.fullname" . }}-migrations
       annotations:
-        {{- range $key, $value := .Values.migrations.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.migrations.podAnnotations }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
     spec:
       restartPolicy: OnFailure
@@ -89,6 +89,6 @@ spec:
 {{ toYaml .Values.migrations.securityContext | indent 8}}
       serviceAccountName: {{ .Values.migrations.serviceAccountName | default (include "reportportal.serviceAccountName" .) }}
 {{- with .Values.tolerations }}
-      tolerations: 
+      tolerations:
 {{- toYaml . | nindent 8 }}
 {{- end }}

--- a/reportportal/templates/service-ui/ui-deployment.yaml
+++ b/reportportal/templates/service-ui/ui-deployment.yaml
@@ -11,13 +11,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- range $key, $value := .Values.serviceui.podLabels }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.serviceui.podLabels }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
-        component: {{ include "reportportal.fullname" . }}-ui
+        component: { { include "reportportal.fullname" . } }-ui
       annotations:
-        {{- range $key, $value := .Values.serviceui.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.serviceui.podAnnotations }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
     spec:
       {{- with .Values.serviceui.affinity }}

--- a/reportportal/templates/statefullset-auto-analyzer/analyzer-statefulset.yaml
+++ b/reportportal/templates/statefullset-auto-analyzer/analyzer-statefulset.yaml
@@ -12,13 +12,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- range $key, $value := .Values.serviceanalyzer.podLabels }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.serviceanalyzer.podLabels }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
-        component: {{ include "reportportal.fullname" . }}-analyzer
+        component: { { include "reportportal.fullname" . } }-analyzer
       annotations:
-        {{- range $key, $value := .Values.serviceanalyzer.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.serviceanalyzer.podAnnotations }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
     spec:
       {{- with .Values.serviceanalyzer.affinity }}

--- a/reportportal/templates/statefullset-auto-analyzer/analyzertrain-statefulset.yaml
+++ b/reportportal/templates/statefullset-auto-analyzer/analyzertrain-statefulset.yaml
@@ -12,13 +12,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- range $key, $value := .Values.serviceanalyzertrain.podLabels }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.serviceanalyzertrain.podLabels }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
-        component: {{ include "reportportal.fullname" . }}-analyzer-train
+        component: { { include "reportportal.fullname" . } }-analyzer-train
       annotations:
-        {{- range $key, $value := .Values.serviceanalyzertrain.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.serviceanalyzertrain.podAnnotations }}
+        {{- toYaml . | nindent 4 }}
         {{- end }}
     spec:
       {{- with .Values.serviceanalyzertrain.affinity }}


### PR DESCRIPTION
While attempting to deploy reportportal using ArgoCD, my teammates and I noticed the deployment was failing due to ArgoCD trying to reconcile the chart with injection modifications done by Kyverno. 

This was determined to be because a loop is executed regardless of content. To correct for this, I've updated the deployment types: jobs, statefulsets, and deployments to use the `with` control structure which only executes if the values are non-empty per [here](https://helm.sh/docs/chart_template_guide/control_structures/#modifying-scope-using-with).

<img width="1428" height="129" alt="image" src="https://github.com/user-attachments/assets/b46f5f7d-94de-4cea-b9ee-1fe3ec5a6b5d" />
