### PR TITLE
Dependencies updates 

### DIFF
--- a/docs/minikube-install.md
+++ b/docs/minikube-install.md
@@ -79,8 +79,8 @@ Call the following commands from the downloaded
 [kubernetes](https://github.com/reportportal/kubernetes/) repository.
 
 ```bash
-# Download the chart dependencies
-helm dependency build ./reportportal 
+# Update the chart dependencies
+helm dependency update ./reportportal
 ```
 
 ```bash

--- a/reportportal/Chart.yaml
+++ b/reportportal/Chart.yaml
@@ -31,19 +31,19 @@ maintainers:
 dependencies:
   # If you update version, please update also postgresql.image.tag in values.yaml
   - name: postgresql
-    version: 15.5.38
+    version: 16.7.21
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.install
     # If you update version, please update also rabbitmq.image.tag in values.yaml
   - name: rabbitmq
-    version: 14.7.0
+    version: 16.0.11
     repository: https://charts.bitnami.com/bitnami
     condition: rabbitmq.install
   - name: opensearch
-    version: 2.27.1
+    version: 2.35.0
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.install
   - name: minio
-    version: 14.10.0
+    version: 17.0.16
     repository: https://charts.bitnami.com/bitnami
     condition: minio.install

--- a/reportportal/Chart.yaml
+++ b/reportportal/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   ReportPortal.io is a TestOps service, that provides increased capabilities
   to speed up results analysis and reporting through the use of built-in analytic features.
 name: reportportal
-version: 25.7.3
+version: 25.7.30
 sources:
   - https://github.com/reportportal/kubernetes/tree/master/reportportal
 keywords:

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -856,7 +856,7 @@ postgresql:
   install: true
   image:
     repository: bitnami/postgresql
-    tag: 16.6.0-debian-12-r2
+    tag: 17.5.0-debian-12-r20
   auth:
     postgresPassword: *dbpassword
     username: *dbuser
@@ -874,7 +874,7 @@ rabbitmq:
   install: true
   image:
     repository: bitnami/rabbitmq
-    tag: 3.13.7-debian-12-r5
+    tag: 4.1.2-debian-12-r1
   auth:
     username: *msgbrokerUser
     password: *msgbrokerPass
@@ -897,7 +897,7 @@ opensearch:
   install: true
   image:
     repository: opensearchproject/opensearch
-    tag: 2.18.0
+    tag: 2.19.3
   ## @param opensearch.singleNode If "true", replicas will be forced from 3 to 1
   ##
   singleNode: true
@@ -919,10 +919,12 @@ minio:
   install: true
   image:
     repository: bitnami/minio
-    tag: 2024.11.7-debian-12-r2
+    tag: 2025.7.23-debian-12-r0
   auth:
     rootUser: *storageAccessKey
     rootPassword: *storageSecretKey
   persistence:
     annotations:
       "helm.sh/resource-policy": "keep"
+  console:
+    enabled: false


### PR DESCRIPTION
This pull request includes updates to the Helm chart and documentation for ReportPortal. The key changes involve updating dependencies and their corresponding image tags, as well as refining the documentation for Helm commands.

### Documentation Update:
* Updated the Helm command in `docs/minikube-install.md` to use `helm dependency update` instead of `helm dependency build` for better clarity and accuracy.

### Helm Chart Updates:
* **Chart Metadata:**
  * Bumped the chart version in `reportportal/Chart.yaml` from `25.7.3` to `25.7.30`.
  * Updated dependency versions in `reportportal/Chart.yaml` for `postgresql`, `rabbitmq`, `opensearch`, and `minio` to their latest compatible versions.

* **Values Configuration:**
  * Updated image tags in `reportportal/values.yaml` for the following dependencies:
    - [`postgresql`](diffhunk://#diff-c554617a65c1ad51602ac8780bbe79db48ddcc7b00106d755361a16301b571ecL859-R859): `16.6.0-debian-12-r2` → `17.5.0-debian-12-r20`
    - [`rabbitmq`](diffhunk://#diff-c554617a65c1ad51602ac8780bbe79db48ddcc7b00106d755361a16301b571ecL877-R877): `3.13.7-debian-12-r5` → `4.1.2-debian-12-r1`
    - [`opensearch`](diffhunk://#diff-c554617a65c1ad51602ac8780bbe79db48ddcc7b00106d755361a16301b571ecL900-R900): `2.18.0` → `2.19.3`
    - [`minio`](diffhunk://#diff-c554617a65c1ad51602ac8780bbe79db48ddcc7b00106d755361a16301b571ecL922-R930): `2024.11.7-debian-12-r2` → `2025.7.23-debian-12-r0`
  * Added a new configuration option in `minio` to disable the console by setting `console.enabled` to `false`.