### PR TITLE
fix: respect global tolerations in Helm hooks jobs

### DIFF
--- a/reportportal/templates/hooks/tests/readiness-test.yaml
+++ b/reportportal/templates/hooks/tests/readiness-test.yaml
@@ -34,4 +34,8 @@ spec:
     resources:
       {{- toYaml .Values.hooks.test.resources | nindent 6 }}
   restartPolicy: Never
+  {{- with .Values.global.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/reportportal/templates/hooks/upgrade/pre-upgrade-cleanup.yaml
+++ b/reportportal/templates/hooks/upgrade/pre-upgrade-cleanup.yaml
@@ -38,4 +38,8 @@ spec:
           kubectl delete job {{ include "reportportal.fullname" . }}-migrations --ignore-not-found=true
         resources:
           {{- toYaml .Values.hooks.preUpgrade.resources | nindent 10 }}
+      {{- with .Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
Resolves #503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring pod tolerations on the readiness-test hook via global values, enabling scheduling on tainted nodes.
  * Added support for configuring pod tolerations on the pre-upgrade-cleanup job via global values, aligning with cluster policies.
  * Tolerations are applied only when provided in global values; default behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->